### PR TITLE
Fix indentation for redis_url in configmap.yaml

### DIFF
--- a/scripts/helm/gimme/templates/configmap.yaml
+++ b/scripts/helm/gimme/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
       enabled: true
       type: {{ .Values.cache.type | quote }}
       ttl: {{ .Values.cache.ttl }}
-      redis_url: {{ .Values.cache.redisUrl | quote }}
+    redis_url: {{ .Values.cache.redisUrl | quote }}
     {{- end }}
     {{- if ne .Values.tokenStore.mode "file" }}
     tokenStore:


### PR DESCRIPTION
I think the commit explains all