### PR TITLE
docs: align rule 8 with the actual branch protection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -42,7 +42,9 @@ Codex does not have the planning conversation. If an issue is ambiguous, that is
    ```
 6. **Code review after implementation.** Invoke the `code-reviewer` sub-agent and address its findings before proposing a commit.
 7. **Never commit automatically.** Propose the message; the decision to commit is the maintainer's.
-8. **Every change goes through a branch and a pull request.** `main` is protected: it requires a pull request and one approving review. Admin accounts can bypass that check — **do not**. The bypass exists for emergencies, not for routine work.
+8. **Every change goes through a branch and a pull request.** `main` is protected — direct pushes are refused, and a pull request cannot merge until the `test` and `helm-test` checks are green. Branches must also be up to date with `main` before merging; if dependabot has landed a bump since you branched, update the branch.
+
+   Admin accounts can bypass the checks. **Do not** — bypassing here means merging with a red CI, which is exactly what the gate exists to prevent.
 
    One branch per task, named after the issue it closes:
    ```
@@ -81,8 +83,9 @@ Before touching application code, so the lint inventory is known in advance.
 
 - [ ] **#52 — `golangci-lint` + `gosec` in CI** *(two steps)*
   **Step A (now):** create `.golangci.yml` (none exists) and add the job with `continue-on-error: true`. The goal is the inventory of existing findings, not a gate.
-  **Step B (after Phase 3):** remove `continue-on-error`, make it a blocking gate.
+  **Step B (after Phase 3):** remove `continue-on-error`, make it a blocking gate. ⚠️ **Also add `lint` to the required status checks** on the `main` branch protection — otherwise the job runs and blocks nothing. Only at step B, never at step A.
   *Files:* `.golangci.yml`, `.github/workflows/build.yml`
+  *Careful:* required check names are coupled to job names in the workflow. Renaming a job without updating the branch protection leaves every pull request waiting on a check that will never report.
   *Note:* `gosec` will most likely flag the upload and file-handling paths touched in Phase 3. Expect overlap; do not fix those findings here.
 
 - [ ] **#53 — Multi-arch Docker image**

--- a/TODO.md
+++ b/TODO.md
@@ -105,10 +105,17 @@ Before touching application code, so the lint inventory is known in advance.
   *Prove it:* the hardest one to red-test. Instrument the mock's `AddObject` with an atomic counter tracking peak concurrency, upload an archive with many entries, assert the peak stays at or below the limit. Before the fix the peak equals the entry count; after, it is capped.
 
 - [ ] **#42 + #43 — ZIP entry handling** ⚠️ *ship together*
-  Same function, same validation. #42: archives without a root folder upload but are unreachable. #43: entry names not starting with `[a-zA-Z0-9-_]` escape the package namespace entirely.
+  Same function, same validation. The rewrite regex replaces the **first path segment, whatever it is**, which is correct only for archives shaped exactly `<one-root-folder>/...`.
+  **This is the most severe defect in the backlog** — reproduced end-to-end against `ziggornif/gimme:latest`, see the issue. Four symptoms, worst last:
+  1. root-level files escape the package namespace and become permanent orphans `DeletePackage` cannot reach
+  2. subdirectories are flattened — the file exists, but not at the URL anyone wrote
+  3. two top-level folders holding the same filename collapse onto one key: **silent data loss**, not a 404
+  4. which of the two wins **varies between uploads of the same archive**
+  #43 is the same code path: entry names not starting with `[a-zA-Z0-9-_]` are not rewritten at all and escape the namespace.
   *Files:* `internal/content/content-service.go`, `internal/content/content-service_test.go`
-  *Prove it:* Go tests. Build fixture archives in-test — one with a root folder, one with files at the root, one with several top-level folders, one with entries named `../x`, `/x`, `.hidden/x`. Assert the resulting object keys. Before the fix, `app.js` yields `awesome-lib@1.0.0.js` and `../../evil.js` passes through untouched.
-  *Approach:* stop inferring structure from a regex. Detect a common root, strip it if present, then assert every resulting key starts with `<pkg>@<version>/` and reject the whole archive otherwise.
+  *Prove it:* Go tests. Build fixture archives in-test — one with a root folder, one with files at the root, one with several top-level folders, one with the same filename in two folders, one with entries named `../x`, `/x`, `.hidden/x`. Assert the resulting object keys. Before the fix, `app.js` yields `awesome-lib@1.0.0.js`, `img/logo.svg` yields `<pkg>@<version>/logo.svg`, and `../../evil.js` passes through untouched.
+  *Approach:* detect a common root and strip only that; otherwise **preserve the full internal path**. Assert every resulting key starts with `<pkg>@<version>/` and reject the archive otherwise. Detect duplicate target keys **before uploading anything** and reject, naming the colliding entries — never overwrite silently.
+  *Note:* symptom 4 most likely comes from the unbounded `errgroup` in #44, which lands first. Fixing #44 makes the collision deterministic; only this task makes it impossible.
 
 - [ ] **#45 + #46 — Version and filename resolution** ⚠️ *ship together*
   Same function, same test table. `pkg@1` currently resolves to `10.0.0`; `/app.js` also matches `app.js.map`.


### PR DESCRIPTION
Rule 8 was written before the branch protection was updated and no longer describes it.

## Current protection

```json
{"require_pr": true, "approvals": 0,
 "checks": ["helm-test", "test"], "checks_strict": true}
```

Rule 8 claimed `main` "requires a pull request and one approving review". The approval count is now 0, and two status checks are required instead — a better gate for a solo maintainer, since GitHub does not allow approving your own pull request.

## Changes

- **Rule 8 restated**: no direct pushes, `test` and `helm-test` must be green, branches must be up to date before merging. The "do not use the admin bypass" instruction now has a concrete meaning — do not merge on a red CI.
- **Task #52 flagged**: when the lint job stops being `continue-on-error` at step B, `lint` must also be added to the required status checks, or it runs without blocking anything. Noted that required check names are coupled to workflow job names — renaming a job without updating protection leaves pull requests waiting forever on a check that never reports.

Documentation only.