### PR TITLE
fix: split malformed .gitignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@
 .DS_Store
 dist
 /gimme
-gimme.yml.worktrees/
+/gimme.yml
+/.worktrees/

--- a/TODO.md
+++ b/TODO.md
@@ -67,7 +67,7 @@ Codex does not have the planning conversation. If an issue is ambiguous, that is
 
 One-line fixes, no dependencies, no behaviour change.
 
-- [ ] **#58 — `.gitignore` malformed pattern**
+- [x] **#58 — `.gitignore` malformed pattern**
   `gimme.yml.worktrees/` is two patterns collapsed into one; neither `gimme.yml` nor `.worktrees/` is actually ignored. Real S3 credentials can be committed.
   *Files:* `.gitignore`
   *Prove it:* not unit-testable — this is the one Phase 1/3 exception to rule 4. Record the shell output instead: `git check-ignore -v gimme.yml` returns nothing before the fix, matches after.


### PR DESCRIPTION
Closes #58.

`.gitignore` ended with a single malformed line — two patterns collapsed into one during a merge:

```
gimme.yml.worktrees/
```

As written it matches neither `gimme.yml` nor `.worktrees/`. `gimme.yml` is the working configuration file (`configs/config.go` reads it from the current directory, and the README tells users to create it with `cp gimme.example.yml gimme.yml`), so a contributor following the documented setup had live S3 access keys, an admin password and the token-signing secret sitting untracked-but-visible in `git status`, ready to be swept up by `git add .`.

## Evidence

Not unit-testable — this is the Phase 1 exception to the failing-test-first rule in `TODO.md`, so the shell output is the artifact.

Before:

```
$ git check-ignore -v gimme.yml
(no output, exit 1) -> NOT IGNORED
$ git check-ignore -v .worktrees/
(no output, exit 1) -> NOT IGNORED
```

After:

```
$ git check-ignore -v gimme.yml
.gitignore:21:/gimme.yml	gimme.yml
$ git check-ignore -v .worktrees/
.gitignore:22:/.worktrees/	.worktrees/
```

## Root anchoring

Both patterns are anchored with a leading `/`, consistent with the `/gimme` entry above them. Unanchored, `gimme.yml` matches at any depth — a future `examples/**/gimme.yml` would be silently ignored. The existing example stays visible:

```
$ git check-ignore -v examples/deployment/docker-compose/with-managed-s3/gimme.yml
(no output) -> not ignored, correct
```

## History

`gimme.yml` was tracked until `cbb83fa` (the commit that meant to add this ignore rule). Its contents were sample values only — `secret: secret`, `s3key`/`s3secret` — so there is nothing to purge from history.

## Checks

| Check | Result |
|---|---|
| `gofmt -l .` | empty |
| `golangci-lint run ./...` | not run — binary not installed locally; this is what #52 adds |
| `make test` | all packages `ok` |
| `make build` | ok |

The `#58` checkbox in `TODO.md` is ticked in this PR, per rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)