### PR TITLE
chore: rename Go module to github.com/ziggornif/gimme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           TEST_S3_LOCATION: garage
         run: |
           go test ./... -coverprofile=coverage.out
-          grep -v "github.com/gimme-cdn/gimme/test/" coverage.out > coverage.tmp && mv coverage.tmp coverage.out
+          grep -v "github.com/ziggornif/gimme/test/" coverage.out > coverage.tmp && mv coverage.tmp coverage.out
 
       - name: Coverage
         run: go tool cover -func coverage.out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **Gimme** is a self-hosted CDN (Content Delivery Network) solution written in Go. It allows uploading packages (ZIP archives) and serving static assets (JS, CSS, images, etc.) via a REST API, backed by any S3-compatible object storage — primarily [Garage HQ](https://garagehq.deuxfleurs.fr/) or [Minio](https://min.io/) via the Minio Go SDK.
 
-- **Module**: `github.com/gimme-cdn/gimme`
+- **Module**: `github.com/ziggornif/gimme`
 - **Go version**: 1.26+
 - **Docker image**: `ziggornif/gimme`
 
@@ -124,7 +124,7 @@ Integration tests (in `api/`) run unconditionally and require a live S3 backend 
 
 Unit tests only (no S3 required):
 ```bash
-go test $(go list ./... | grep -v 'github.com/gimme-cdn/gimme/api') -coverprofile=coverage.out
+go test $(go list ./... | grep -v 'github.com/ziggornif/gimme/api') -coverprofile=coverage.out
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 
 ```bash
 # Clone the repository
-git clone https://github.com/gimme-cdn/gimme.git
+git clone https://github.com/ziggornif/gimme.git
 cd gimme
 
 # Copy the example config
@@ -27,7 +27,7 @@ cp gimme.example.yml gimme.yml
 go mod download
 
 # Run unit tests (no S3 required)
-go test $(go list ./... | grep -v 'github.com/gimme-cdn/gimme/api') -coverprofile=coverage.out
+go test $(go list ./... | grep -v 'github.com/ziggornif/gimme/api') -coverprofile=coverage.out
 
 # Run all tests including integration (starts Garage via Docker automatically)
 make test
@@ -124,7 +124,7 @@ make helm-test   # run unit tests
 
 ## Reporting Issues
 
-Please open an issue on [GitHub](https://github.com/gimme-cdn/gimme/issues) with:
+Please open an issue on [GitHub](https://github.com/ziggornif/gimme/issues) with:
 - A clear description of the problem
 - Steps to reproduce
 - Expected vs actual behaviour

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test: garage-start
 	 TEST_S3_BUCKET=gimme TEST_S3_LOCATION=garage \
 	 go test ./... -coverprofile=coverage.out; \
 	 TEST_EXIT=$$?; \
-	 grep -v "github.com/gimme-cdn/gimme/test/" coverage.out > coverage.tmp && mv coverage.tmp coverage.out; \
+	 grep -v "github.com/ziggornif/gimme/test/" coverage.out > coverage.tmp && mv coverage.tmp coverage.out; \
 	 $(MAKE) garage-stop; \
 	 exit $$TEST_EXIT
 

--- a/TODO.md
+++ b/TODO.md
@@ -73,6 +73,11 @@ One-line fixes, no dependencies, no behaviour change.
   *Prove it:* not unit-testable — this is the one Phase 1/3 exception to rule 4. Record the shell output instead: `git check-ignore -v gimme.yml` returns nothing before the fix, matches after.
   *Done when:* `git check-ignore gimme.yml` and `git check-ignore .worktrees/` both match.
 
+- [x] **#70 — Canonical Go module path**
+  Rename the module and its internal imports to `github.com/ziggornif/gimme`, matching the repository's canonical identity. Keep the path unversioned — **no `/v3` suffix**, even though Phase 5 tags a major: gimme is a server, nothing imports it, and releases ship as binaries and Docker images, so the module path is an internal identifier no proxy ever resolves.
+  *Files:* `go.mod`, Go imports, coverage filters, `CONTRIBUTING.md`, `CLAUDE.md`
+  *Watch:* the coverage filters in `Makefile` and `.github/workflows/build.yml` match the module path as a literal string. Miss one and it silently stops excluding `test/mocks` — nothing turns red.
+
 > **Optional pull-forward:** the version badge in #63 says `v1` while the latest release is v2.0.9 — publicly wrong right now, one line in `docs/site/index.html`. Fix it here if convenient; the rest of #63 stays in Phase 4.
 
 ---
@@ -219,4 +224,6 @@ Release notes are auto-generated from PR titles in GitHub Releases. **Add a hand
 
 ## Open decisions
 
-- **Project identity.** The Go module declares `github.com/gimme-cdn/gimme`, README badges point at `ziggornif/gimme`, and the repository currently resolves to `drouian-m/gimme`. It works through redirects but is confusing for `go install`. Worth settling before the release. *Related:* #63.
+_None open._
+
+Project identity was settled in #70: repository, Go module and Docker image are all `ziggornif/gimme`, and the module path deliberately carries no major-version suffix.

--- a/api/admin-controller.go
+++ b/api/admin-controller.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gimme-cdn/gimme/internal/auth"
-	"github.com/gimme-cdn/gimme/internal/errors"
 	"github.com/gin-gonic/gin"
+	"github.com/ziggornif/gimme/internal/auth"
+	"github.com/ziggornif/gimme/internal/errors"
 )
 
 // AdminController handles the admin UI and token management API.

--- a/api/admin-controller_test.go
+++ b/api/admin-controller_test.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gimme-cdn/gimme/internal/auth"
-	"github.com/gimme-cdn/gimme/test/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ziggornif/gimme/internal/auth"
+	"github.com/ziggornif/gimme/test/utils"
 )
 
 const adminAuthHeader = "Basic dGVzdDp0ZXN0" // test:test

--- a/api/health-controller.go
+++ b/api/health-controller.go
@@ -3,8 +3,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/gimme-cdn/gimme/internal/storage"
 	"github.com/gin-gonic/gin"
+	"github.com/ziggornif/gimme/internal/storage"
 )
 
 type HealthController struct {

--- a/api/health-controller_test.go
+++ b/api/health-controller_test.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/gimme-cdn/gimme/test/mocks"
-	"github.com/gimme-cdn/gimme/test/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/ziggornif/gimme/test/mocks"
+	"github.com/ziggornif/gimme/test/utils"
 )
 
 func TestHealthControllerLiveness(t *testing.T) {

--- a/api/package-controller.go
+++ b/api/package-controller.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gimme-cdn/gimme/internal/archive_validator"
-	"github.com/gimme-cdn/gimme/internal/auth"
-	"github.com/gimme-cdn/gimme/internal/content"
-	"github.com/gimme-cdn/gimme/internal/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/minio/minio-go/v7"
 	"github.com/sirupsen/logrus"
+	"github.com/ziggornif/gimme/internal/archive_validator"
+	"github.com/ziggornif/gimme/internal/auth"
+	"github.com/ziggornif/gimme/internal/content"
+	"github.com/ziggornif/gimme/internal/errors"
 )
 
 type PackageController struct {

--- a/api/package-controller_integration_test.go
+++ b/api/package-controller_integration_test.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gimme-cdn/gimme/internal/auth"
-	"github.com/gimme-cdn/gimme/internal/content"
-	"github.com/gimme-cdn/gimme/test/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/ziggornif/gimme/internal/auth"
+	"github.com/ziggornif/gimme/internal/content"
+	"github.com/ziggornif/gimme/test/utils"
 )
 
 func newTestAuthManager(t *testing.T) *auth.AuthManager {

--- a/api/package-controller_test.go
+++ b/api/package-controller_test.go
@@ -12,15 +12,15 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gimme-cdn/gimme/configs"
-	"github.com/gimme-cdn/gimme/internal/auth"
-	"github.com/gimme-cdn/gimme/internal/content"
-	"github.com/gimme-cdn/gimme/internal/storage"
-	"github.com/gimme-cdn/gimme/test/mocks"
-	"github.com/gimme-cdn/gimme/test/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ziggornif/gimme/configs"
+	"github.com/ziggornif/gimme/internal/auth"
+	"github.com/ziggornif/gimme/internal/content"
+	"github.com/ziggornif/gimme/internal/storage"
+	"github.com/ziggornif/gimme/test/mocks"
+	"github.com/ziggornif/gimme/test/utils"
 )
 
 // newPackageTestStore creates a FileTokenStore in a temp dir for controller tests.

--- a/api/root_test.go
+++ b/api/root_test.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/gimme-cdn/gimme/test/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/ziggornif/gimme/test/utils"
 )
 
 func TestNewRootController(t *testing.T) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/gimme-cdn/gimme/internal/application"
+	"github.com/ziggornif/gimme/internal/application"
 )
 
 func main() {

--- a/configs/config.go
+++ b/configs/config.go
@@ -3,7 +3,7 @@ package configs
 import (
 	"fmt"
 
-	"github.com/gimme-cdn/gimme/internal/errors"
+	"github.com/ziggornif/gimme/internal/errors"
 
 	"github.com/sirupsen/logrus"
 

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gimme-cdn/gimme/test/utils"
+	"github.com/ziggornif/gimme/test/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gimme-cdn/gimme
+module github.com/ziggornif/gimme
 
 go 1.26
 

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -15,19 +15,19 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gimme-cdn/gimme/api"
-	"github.com/gimme-cdn/gimme/configs"
-	"github.com/gimme-cdn/gimme/internal/auth"
-	"github.com/gimme-cdn/gimme/internal/cache"
-	"github.com/gimme-cdn/gimme/internal/content"
-	gimmeerr "github.com/gimme-cdn/gimme/internal/errors"
-	"github.com/gimme-cdn/gimme/internal/metrics"
-	"github.com/gimme-cdn/gimme/internal/persistence"
-	"github.com/gimme-cdn/gimme/internal/storage"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
+	"github.com/ziggornif/gimme/api"
+	"github.com/ziggornif/gimme/configs"
+	"github.com/ziggornif/gimme/internal/auth"
+	"github.com/ziggornif/gimme/internal/cache"
+	"github.com/ziggornif/gimme/internal/content"
+	gimmeerr "github.com/ziggornif/gimme/internal/errors"
+	"github.com/ziggornif/gimme/internal/metrics"
+	"github.com/ziggornif/gimme/internal/persistence"
+	"github.com/ziggornif/gimme/internal/storage"
 )
 
 type Application struct {

--- a/internal/archive_validator/archive-validator.go
+++ b/internal/archive_validator/archive-validator.go
@@ -6,8 +6,8 @@ import (
 	"mime/multipart"
 	"slices"
 
-	"github.com/gimme-cdn/gimme/internal/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/ziggornif/gimme/internal/errors"
 )
 
 var validTypes = []string{"application/octet-stream", "application/zip"}

--- a/internal/auth/auth-manager.go
+++ b/internal/auth/auth-manager.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gimme-cdn/gimme/internal/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"github.com/ziggornif/gimme/internal/errors"
 )
 
 // tokenPrefix is prepended to every opaque token so that it is immediately

--- a/internal/auth/auth-manager_test.go
+++ b/internal/auth/auth-manager_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gimme-cdn/gimme/test/utils"
+	"github.com/ziggornif/gimme/test/utils"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"

--- a/internal/auth/redis-token-store.go
+++ b/internal/auth/redis-token-store.go
@@ -7,9 +7,9 @@ import (
 	"slices"
 	"time"
 
-	"github.com/gimme-cdn/gimme/internal/persistence"
 	"github.com/redis/go-redis/v9"
 	"github.com/sirupsen/logrus"
+	"github.com/ziggornif/gimme/internal/persistence"
 )
 
 const (

--- a/internal/auth/redis-token-store_test.go
+++ b/internal/auth/redis-token-store_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/gimme-cdn/gimme/internal/persistence"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ziggornif/gimme/internal/persistence"
 )
 
 // newTestRedisStore spins up an in-process miniredis server and returns a

--- a/internal/cache/redis-cache.go
+++ b/internal/cache/redis-cache.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gimme-cdn/gimme/internal/persistence"
 	"github.com/redis/go-redis/v9"
 	"github.com/sirupsen/logrus"
+	"github.com/ziggornif/gimme/internal/persistence"
 )
 
 type redisCache struct {

--- a/internal/cache/redis-cache_test.go
+++ b/internal/cache/redis-cache_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/gimme-cdn/gimme/internal/persistence"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ziggornif/gimme/internal/persistence"
 )
 
 // newTestRedisCache spins up an in-process miniredis server and returns a

--- a/internal/content/content-service.go
+++ b/internal/content/content-service.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gimme-cdn/gimme/internal/cache"
-	"github.com/gimme-cdn/gimme/internal/errors"
-	"github.com/gimme-cdn/gimme/internal/metrics"
-	"github.com/gimme-cdn/gimme/internal/storage"
 	"github.com/minio/minio-go/v7"
 	"github.com/sirupsen/logrus"
+	"github.com/ziggornif/gimme/internal/cache"
+	"github.com/ziggornif/gimme/internal/errors"
+	"github.com/ziggornif/gimme/internal/metrics"
+	"github.com/ziggornif/gimme/internal/storage"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 )

--- a/internal/content/content-service_test.go
+++ b/internal/content/content-service_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gimme-cdn/gimme/internal/cache"
-	"github.com/gimme-cdn/gimme/internal/errors"
-	"github.com/gimme-cdn/gimme/internal/metrics"
-	"github.com/gimme-cdn/gimme/test/mocks"
 	"github.com/minio/minio-go/v7"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ziggornif/gimme/internal/cache"
+	"github.com/ziggornif/gimme/internal/errors"
+	"github.com/ziggornif/gimme/internal/metrics"
+	"github.com/ziggornif/gimme/test/mocks"
 )
 
 func TestContentService_CreatePackage(t *testing.T) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gimme-cdn/gimme/internal/metrics"
+	"github.com/ziggornif/gimme/internal/metrics"
 )
 
 func TestHTTPRequestsTotal_Inc(t *testing.T) {

--- a/internal/storage/objectstorage-client.go
+++ b/internal/storage/objectstorage-client.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/gimme-cdn/gimme/internal/errors"
+	"github.com/ziggornif/gimme/internal/errors"
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/gimme-cdn/gimme/configs"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/ziggornif/gimme/configs"
 
 	"github.com/minio/minio-go/v7"
 )

--- a/internal/storage/objectstorage-client_test.go
+++ b/internal/storage/objectstorage-client_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/gimme-cdn/gimme/configs"
+	"github.com/ziggornif/gimme/configs"
 )
 
 func TestNewObjectStorageClient(t *testing.T) {

--- a/internal/storage/objectstorage-manager.go
+++ b/internal/storage/objectstorage-manager.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gimme-cdn/gimme/internal/errors"
-	"github.com/gimme-cdn/gimme/internal/metrics"
+	"github.com/ziggornif/gimme/internal/errors"
+	"github.com/ziggornif/gimme/internal/metrics"
 
-	fileutils "github.com/gimme-cdn/gimme/pkg/file-utils"
+	fileutils "github.com/ziggornif/gimme/pkg/file-utils"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/sirupsen/logrus"

--- a/internal/storage/objectstorage-manager_test.go
+++ b/internal/storage/objectstorage-manager_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/minio/minio-go/v7"
 
-	"github.com/gimme-cdn/gimme/test/mocks"
+	"github.com/ziggornif/gimme/test/mocks"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/test/mocks/cache-manager.go
+++ b/test/mocks/cache-manager.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gimme-cdn/gimme/internal/cache"
+	"github.com/ziggornif/gimme/internal/cache"
 )
 
 // MockCacheManager is an in-memory CacheManager for unit tests.

--- a/test/mocks/objectstorage-manager-err.go
+++ b/test/mocks/objectstorage-manager-err.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gimme-cdn/gimme/internal/errors"
+	"github.com/ziggornif/gimme/internal/errors"
 
 	"github.com/minio/minio-go/v7"
 )

--- a/test/mocks/objectstorage-manager-exists.go
+++ b/test/mocks/objectstorage-manager-exists.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gimme-cdn/gimme/internal/errors"
+	"github.com/ziggornif/gimme/internal/errors"
 
 	"github.com/minio/minio-go/v7"
 )

--- a/test/mocks/objectstorage-manager.go
+++ b/test/mocks/objectstorage-manager.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/gimme-cdn/gimme/internal/errors"
+	"github.com/ziggornif/gimme/internal/errors"
 
 	"github.com/minio/minio-go/v7"
 )


### PR DESCRIPTION
Closes #70.

The Go module declared `github.com/gimme-cdn/gimme` while the repository is `ziggornif/gimme`. Renamed throughout, **without** a major-version suffix.

## What was actually broken

`CONTRIBUTING.md` sent contributors to an organisation that does not host this project:

```
CONTRIBUTING.md:19    git clone https://github.com/gimme-cdn/gimme.git    -> 404
CONTRIBUTING.md:127   "open an issue on GitHub" -> gimme-cdn/gimme        -> 404
```

Following the documented setup, you could not clone the project.

## Why no `/v3` suffix

Go requires a `/vN` suffix from major 2 onward. The module never took it, so the proxy stops at v1.1.1:

```
$ go list -m -versions github.com/gimme-cdn/gimme
github.com/gimme-cdn/gimme v0.1.0 v0.2.0 v0.2.1 v0.3.0 v1.0.0 v1.1.0 v1.1.1

$ go list -m github.com/gimme-cdn/gimme@v2.0.9
404: invalid version: module contains a go.mod file,
     so module path must match major version ("github.com/gimme-cdn/gimme/v2")
```

Deliberately left that way. gimme is a server: nothing imports it, releases ship as binaries and Docker images, and no documentation offers a `go install` of gimme (the only one in the repo installs `air`). `go build ./cmd/server` ignores the declared path. A suffix would satisfy a rule no consumer exercises, at the cost of one in every import line.

## The silent failure mode

`Makefile:46` and `.github/workflows/build.yml:85` filter coverage by matching the module path as a **literal string**:

```
grep -v "github.com/ziggornif/gimme/test/" coverage.out
```

Miss one and it simply stops matching: `test/mocks` re-enters the coverage figure and nothing turns red. Both are updated, and the result is checked below.

## Verification

No behaviour changes, so the tests are indifferent to this rename — they pass before and after. The meaningful checks are that nothing broke and that the silent failure did not happen:

| Check | Result |
|---|---|
| `gofmt -l .` | empty |
| `go mod tidy` | no dependency change |
| `make build` | ok |
| `make test` | all packages `ok`, coverage percentages unchanged (api 86.5%, configs 99.1%, content 95.3%) |
| `grep -c "gimme/test/" coverage.out` | `0` — filter still excludes the mocks |
| `git clone https://github.com/ziggornif/gimme.git` | resolves |

`.idea/workspace.xml` still holds the old path and is left alone: it is gitignored and refers to packages (`internal/domain/gimmecdn`) that no longer exist.

The `#70` entry is added to `TODO.md` and the *Open decisions* project-identity entry is closed out, per rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)