### PR TITLE
docs: make the Codex handoff in work-issue actually executable

### DIFF
--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -5,7 +5,16 @@ description: Use when picking up a numbered issue from the gimme backlog, when a
 
 # Work an issue
 
-Claude plans, Codex implements. Codex never sees the planning conversation — everything it needs lives in the issue and in `TODO.md`.
+Four hands, in order:
+
+| Who | Does |
+|---|---|
+| Claude | plans, writes the issue, writes Codex's prompt |
+| Codex | implements, reviews its own diff |
+| Claude | reviews second, with a reviewing sub-agent |
+| Sonnet agent | runs the quality gate |
+
+Codex never sees the planning conversation and cannot fetch the missing context itself — everything it needs must be **in the prompt**, copied out of the issue and `TODO.md` by the agent writing that prompt. And it cannot run the suite: that is why the gate is dispatched to an agent with an ordinary shell.
 
 ## Order of operations
 
@@ -38,9 +47,36 @@ The artifact is not always a Go test: `helm-unittest` for chart bugs, a recorded
 
 **4. Delegate the implementation to Codex**
 
-Hand over the issue number and the branch. If Codex has to ask what the change is, the issue is underspecified — fix the issue, don't answer from memory.
+```bash
+codex exec --full-auto "<self-contained prompt>"
+```
 
-**5. Verify before proposing anything**
+**Never tell Codex to read the issue.** Its `gh` cannot authenticate: the token lives in the macOS keyring, not in `~/.config/gh/hosts.yml`, and `gh auth status` inside the sandbox reports *the token in default is invalid*. The failure surfaces as `error connecting to api.github.com`, which is misleading — `curl https://api.github.com` returns `200` from that same sandbox. Codex does not stop on the missing issue; it guesses, and the guess can look right.
+
+So the prompt carries, in full text: the branch name, the scope, the files, what to leave alone, the failure modes to watch, and the decisions already taken — including the ones considered and rejected, so Codex does not re-open them. Reading the issue and assembling that is the planning agent's job.
+
+Ask Codex to review its own work before returning: a first pass on its own diff against the stated scope.
+
+**Do not ask it for the test suite.** The sandbox denies `bind`, so any test opening a listener panics before it does anything useful:
+
+```
+panic: httptest: failed to listen on a port:
+       listen tcp6 [::1]:0: bind: operation not permitted
+```
+
+That hits `api/` and `internal/storage/` (both use `httptest.NewServer`) plus the Redis and listener tests. Pre-starting Garage does not help — the wall is `bind`, not Docker. `gofmt -l .` and `make build` are the only checks worth asking Codex for.
+
+If the issue is too thin to write such a prompt, that is a planning defect. Fix the issue, don't fill the gap from memory.
+
+If the task has no entry in `TODO.md` — an issue filed mid-flight, say — add one in the same branch. An issue that never reaches `TODO.md` is invisible to the next session.
+
+**5. Review, then have the tests run**
+
+Codex never exercised the change, so nothing is verified yet.
+
+Review the diff yourself first — second pass, after Codex's own. Then hand it to a reviewing sub-agent: `code-reviewer` does not exist in every setup, `caveman:cavecrew-reviewer` does. Give it the issue context and the checks already run, so it verifies rather than repeats.
+
+Then dispatch a **Sonnet agent** to run the gate. It has an ordinary shell, so Docker and `bind` are available to it:
 
 ```bash
 gofmt -l .              # must output nothing
@@ -49,7 +85,9 @@ make test               # starts and stops Garage
 make build
 ```
 
-Then invoke the `code-reviewer` sub-agent and address what it finds.
+Ask it for the raw output, not a verdict. Codex reported #70's failures as "sandbox network restrictions" and the real cause was `bind`; a summarised result is where a wrong diagnosis hides.
+
+`golangci-lint` is not installed on every machine (`No such file or directory`). Report it as not run — never as passing. Installing it is #52's job, not the current task's.
 
 **6. Pull request**
 
@@ -66,6 +104,7 @@ Propose the commit message; the maintainer decides when to commit.
 | Task order, pairings, gates | `TODO.md` |
 | Cause, evidence, fix, tests | the GitHub issue |
 | Branch | `<type>/<issue>-<slug>`, off fresh `main` |
+| Who runs the suite | a Sonnet agent — not Codex, whose sandbox denies `bind` |
 | Merge gate | `test` + `helm-test` green |
 | Release | Phase 5 only — no tags before |
 
@@ -81,6 +120,9 @@ Stop if you catch yourself thinking:
 | "CI is red but it's unrelated" | Do not merge red. Do not use the admin bypass. |
 | "I'll push straight to main, it's one line" | `main` is protected. Branch and PR, every time. |
 | "The issue is vague, I'll infer the intent" | Underspecified issue = planning defect. Raise it. |
+| "I'll tell Codex to go read the issue" | Its `gh` has no usable token. Paste the content into the prompt. |
+| "Codex says the tests pass" | Its sandbox denies `bind`; the suite never ran. Dispatch a Sonnet agent. |
+| "The agent says it's green" | Ask for the raw output. A summary is where a wrong diagnosis hides. |
 | "I'll tag a release now that this landed" | Everything ships in one release at Phase 5. |
 
 ## Common mistakes


### PR DESCRIPTION
Corrections to `.claude/skills/work-issue/SKILL.md`, all found by following it on #58 and #70.

## The main one

Step 4 read:

> Hand over the issue number and the branch.

Following it literally produced this prompt:

```
Work GitHub issue #70 ... Read it first with 'gh issue view 70'
```

Codex could not run that command. It implemented the issue anyway, from inference. The result happened to be correct, which is the dangerous outcome — the same prompt on a subtler issue produces a plausible wrong change.

## What Codex can and cannot do, measured

Codex reported its own failures as *"sandbox network restrictions"*. That was wrong, and repeating it without checking would have put a wrong diagnosis into the skill:

| Command | Result |
|---|---|
| `curl https://api.github.com` | `200` — the network is fine |
| `gh auth status` | `the token in default is invalid` |
| `docker version` | `permission denied ... docker.sock` |
| `go test ./internal/storage/...` | see below |

```
panic: httptest: failed to listen on a port:
       listen tcp6 [::1]:0: bind: operation not permitted
    net/http/httptest.newLocalListener()
    internal/storage.TestNewObjectStorageClient
```

Two distinct causes, neither of them the network:

- **`gh` fails on credentials.** The token lives in the macOS keyring, not in `~/.config/gh/hosts.yml`, and the sandbox cannot open it. The error text says "error connecting to api.github.com", which is what sent both Codex and me down the wrong path.
- **The suite fails on `bind`.** Tests that open a listener panic before doing anything. That covers `api/` and `internal/storage/` (both use `httptest.NewServer`) plus the Redis and listener tests. Starting Garage beforehand does not help — verified, the container was up and the panic was identical.

## The chain the skill now describes

| Who | Does |
|---|---|
| Claude | plans, writes the issue, writes Codex's prompt |
| Codex | implements, reviews its own diff |
| Claude | reviews second, with a reviewing sub-agent |
| Sonnet agent | runs the quality gate |

The Sonnet agent has an ordinary shell, so Docker and `bind` are available to it. The skill also says to ask it for **raw output rather than a verdict** — a summarised result is precisely where the wrong diagnosis hid.

## Three smaller gaps

- **`code-reviewer` does not exist** as a sub-agent in this setup. Step 5 named it anyway; `caveman:cavecrew-reviewer` is a working fallback.
- **`golangci-lint` is not installed** on this machine (`No such file or directory`). The skill now says to report it as not run rather than let it pass silently inside a "gate passed" claim. Installing it is #52's job.
- **An issue filed mid-flight has no `TODO.md` entry.** #70 was created during the session; the skill assumed every task already had a line. It now says to add one in the same branch.

## Verification

The gate was run through the new chain — a Sonnet agent, reporting raw output:

| Check | Result |
|---|---|
| `gofmt -l .` | exit 0, empty |
| `golangci-lint run ./...` | exit 1 — `No such file or directory`, binary absent |
| `make test` | exit 0, all packages `ok` |
| `make build` | exit 0 |

Documentation only — no code, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)