### PR TITLE
docs(helm): qualify the scaling claim and document file-mode ephemerality

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -200,7 +200,7 @@ Before touching application code, so the lint inventory is known in advance.
 - [ ] **#55 — GitHub Action + upload CLI**
   Depends on #42: the archive layout must be settled first. The tool building the ZIP is what structurally prevents #42 from recurring.
 
-- [ ] **#57 — Helm chart README**
+- [x] **#57 — Helm chart README**
   The chart itself is correct — templates, `values.yaml` and the `emptyDir` are all right. Only the README is wrong: it claims horizontal scaling is safe without qualifying that a shared token store is required, its HPA example leaves `mode: file`, its options table has drifted from `values.yaml` (missing `postgres` and `pgUrl`), and file-mode ephemerality is stated nowhere.
   *Files:* `scripts/helm/gimme/README.md` — **documentation only, no template change**
   *Note:* the token store is the *only* thing blocking horizontal scaling. OIDC sessions already scale — the signing key is derived deterministically from the shared `GIMME_SECRET`, so any pod validates any pod's cookie.

--- a/scripts/helm/gimme/README.md
+++ b/scripts/helm/gimme/README.md
@@ -86,7 +86,8 @@ s3:
 | `auth.oidc.redirectUrl` | OIDC redirect URI (required when `auth.mode=oidc`) | `""` |
 | `auth.oidc.secureCookies` | Enable secure cookies (set to `false` for local HTTP dev) | `true` |
 | `credentials.oidcClientSecret` | OIDC client secret (required when `auth.mode=oidc`) | `""` |
-| `tokenStore.mode` | Token store backend: `file` (standalone) or `redis` | `file` |
+| `tokenStore.mode` | Token store backend: `file`, `redis` or `postgres` | `file` |
+| `tokenStore.pgUrl` | PostgreSQL URL (required when `tokenStore.mode=postgres`) | `""` |
 | `service.type` | Kubernetes Service type | `ClusterIP` |
 | `service.port` | Service port | `80` |
 | `ingress.enabled` | Enable Ingress | `false` |
@@ -147,10 +148,22 @@ cache:
 
 ### With HPA (auto-scaling)
 
-Gimme is stateless (all state lives in S3), so horizontal scaling is safe.
+Horizontal scaling requires a shared token store. Everything else in gimme already
+scales — but in the default `file` mode, tokens live in a per-pod volume, so a token
+issued by one pod is unknown to the others.
+
+Set `tokenStore.mode` to `redis` or `postgres` before adding replicas:
 
 ```yaml
 replicaCount: 2
+
+tokenStore:
+  mode: redis
+
+cache:
+  enabled: true
+  type: redis
+  redisUrl: redis://my-redis-service:6379
 
 hpa:
   enabled: true
@@ -158,6 +171,48 @@ hpa:
   maxReplicas: 10
   targetCPUUtilizationPercentage: 70
 ```
+
+`redis` is the natural choice: if you also enable the version-resolution cache, one
+dependency serves both.
+
+#### What scales, and what does not
+
+| State | Shared across pods? |
+|---|---|
+| Token store, `file` mode | **no** — one file per pod |
+| Token store, `redis` / `postgres` | yes |
+| S3 objects | yes, by definition |
+| Version-resolution cache | yes (Redis). With the cache off, each pod resolves independently — slower, still correct |
+| OIDC sessions | yes |
+| OIDC state / nonce | validated against browser cookies, no server-side state |
+
+OIDC scales without extra configuration because the session signing key is derived
+from the shared secret. Every pod reads the same `GIMME_SECRET` from the same
+Kubernetes Secret, derives the same key, and can therefore validate a cookie issued
+by any other pod.
+
+The token store is the only thing standing between this chart and horizontal scaling.
+
+### Token durability in `file` mode
+
+`file` mode is the zero-dependency option: no Redis, no PostgreSQL. The chart mounts
+an `emptyDir` at `/tmp` for it, which is required — `readOnlyRootFilesystem: true`
+would otherwise leave the token store nowhere to write.
+
+An `emptyDir` lives and dies with the **pod**, not the container:
+
+| Event | Tokens survive? |
+|---|---|
+| Container crash and restart in the same pod | **yes** |
+| Liveness probe kill | **yes** |
+| Container OOM kill | **yes** |
+| Pod replaced — `helm upgrade`, image update, node drain, eviction, scale down | **no** |
+
+The last row is the one that matters in practice: **`helm upgrade` replaces pods, so
+upgrading gimme discards every issued API token.** Clients must be re-issued tokens
+after an upgrade.
+
+Use `redis` or `postgres` if tokens need to outlive a pod.
 
 ## Upgrade
 


### PR DESCRIPTION
Closes #57.

The Helm chart is correct — templates, `values.yaml` and the `emptyDir` are all right. Only the README was wrong, and it was wrong in the direction that costs an operator a production incident.

## The claim

`scripts/helm/gimme/README.md`, *With HPA (auto-scaling)*:

> Gimme is stateless (all state lives in S3), so horizontal scaling is safe.

Tokens do not live in S3. In the default `file` mode they live in a per-pod `emptyDir`, so a token issued by one pod is unknown to every other. The example under that sentence set `replicaCount: 2` and left `tokenStore.mode` at its default — following it produces intermittent 401s that look like a client bug.

The example now sets a shared token store, and the claim is qualified.

## What actually scales

Everything except the token store, which the README now states explicitly:

| State | Shared across pods? |
|---|---|
| Token store, `file` mode | **no** — one file per pod |
| Token store, `redis` / `postgres` | yes |
| S3 objects | yes, by definition |
| Version-resolution cache | yes (Redis); with the cache off each pod resolves independently — slower, still correct |
| OIDC sessions | yes |
| OIDC state / nonce | validated against browser cookies, no server-side state |

OIDC needs no extra configuration, which is worth documenting because it looks like it should. Verified in `internal/application/application.go:99`:

```go
oidcSigningSecret := deriveSecret(app.config.Secret, "oidc-session")
```

`deriveSecret` is HMAC-SHA256 over the master secret. Every pod reads the same `GIMME_SECRET` from the same Kubernetes Secret, so every pod derives the same key and validates any other pod's cookie.

## File-mode durability

The chart mounts an `emptyDir` at `/tmp` when `tokenStore.mode: file` (`deployment.yaml:118-121`). That is deliberate and necessary: `readOnlyRootFilesystem: true` in `values.yaml:35` would otherwise leave the token store nowhere to write.

An `emptyDir` lives and dies with the **pod**, not the container — a distinction the README never made:

| Event | Tokens survive? |
|---|---|
| Container crash and restart in the same pod | **yes** |
| Liveness probe kill | **yes** |
| Container OOM kill | **yes** |
| Pod replaced — `helm upgrade`, image update, node drain, eviction, scale down | **no** |

The consequence is stated plainly: **`helm upgrade` replaces pods, so upgrading gimme discards every issued API token.** The word `(standalone)` in a table cell did not convey that.

## Options table

Realigned with `values.yaml`, which was the accurate one:

- `tokenStore.mode` listed only `file` and `redis` — `postgres` was missing
- `tokenStore.pgUrl` was absent entirely

## Verification

| Check | Result |
|---|---|
| `helm lint` | `1 chart(s) linted, 0 chart(s) failed` |
| `npx markdownlint-cli2` | `0 issues in 10 files` |
| `helm unittest` | **not run** — the plugin is not installed locally; the `helm-test` CI job covers it |

Claims checked against the source rather than taken from the issue: the `emptyDir` condition, `readOnlyRootFilesystem: true`, and the determinism of `deriveSecret`.

Documentation only — no template or values change, so chart behaviour is unchanged.

## Side effect worth watching

This branch touches only `.md` files, so it is the first real exercise of the path filtering merged in #75: `test` and `lint` should report **Skipped** while `helm-test` and `markdown` run, and the PR should stay mergeable. `helm-test` runs because `scripts/helm/**` matches the helm filter — correct, if slightly generous for a README.

#65 (a `fail` guard blocking `file` + multiple replicas) lands next, per `TODO.md`, so the guard message and this documentation agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)