### PR TITLE
ci: one pipeline per commit, cancel stale runs, keep helm-test off Markdown

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,18 @@
 name: Docker Image CI
 
 on:
+  # Only main on push: the build job publishes :latest from there. Branches are
+  # covered by pull_request — listening to both on every branch ran two full
+  # pipelines per commit, on the same SHA.
   push:
-    branches: [ "**" ]
+    branches: [ main ]
   pull_request:
-    branches: [ "**" ]
+
+# A new push supersedes the run in flight for the same ref; nobody reads the
+# result of a run for a commit that is no longer the tip.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changes:
@@ -32,6 +40,8 @@ jobs:
               - '.github/workflows/**'
             helm:
               - 'scripts/helm/**'
+              # A README cannot break a template — it belongs to the docs filter.
+              - '!scripts/helm/**/*.md'
               - '.github/workflows/**'
             docs:
               - '**/*.md'

--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,11 @@ Before touching application code, so the lint inventory is known in advance.
   *Files:* `.github/workflows/build.yml`, `.markdownlint-cli2.jsonc`, Markdown files
   *Prove it:* the CI run itself — none of this is observable locally. A branch touching only a `.md` file must show `test` and `helm-test` as **Skipped** and stay mergeable; that is where the required-check deadlock would appear.
 
+- [x] **#77 — CI plumbing: duplicate pipelines, no concurrency, `helm-test` on Markdown**
+  Three defects that together doubled the CI bill. `push` and `pull_request` both listened on `**`, so every commit on a branch with an open pull request ran two complete pipelines on the same SHA. No `concurrency` group, so successive pushes ran in parallel instead of superseding each other. And the `helm` path filter matched `scripts/helm/**/*.md`, firing `helm-test` on documentation-only changes.
+  *Files:* `.github/workflows/build.yml`
+  *Prove it:* CI behaviour, not observable locally. One run per push; a second push cancels the first; a pull request touching only `scripts/helm/**/*.md` shows `helm-test` as **Skipped** while one touching a template still runs it.
+
 - [ ] **#53 — Multi-arch Docker image**
   Binaries are already built for 7 platforms and the Dockerfile already honours `TARGETOS`/`TARGETARCH`. Only the two `docker build` steps need buildx.
   *Files:* `.github/workflows/build.yml`, `.github/workflows/release.yml`


### PR DESCRIPTION
Closes #77.

Three plumbing defects in `build.yml`. Individually small, together they made the CI do roughly twice the work it needed to — undercutting the path filtering added in #74.

## 1. Every commit ran two full pipelines

```yaml
on:
  push:
    branches: [ "**" ]
  pull_request:
    branches: [ "**" ]
```

Once a pull request existed, every push to its branch triggered a `push` run **and** a `pull_request` run on the same SHA. Observed on #76:

```
run 30700441776  event: pull_request  docs/57-helm-readme
run 30700427733  event: push          docs/57-helm-readme
```

On a code branch that is two Garage containers provisioned and two full Go suites for a single push. This predates #74 — it has been doubling the bill on every branch since the workflow was written.

Push now listens on `main` only, where the `build` job publishes `:latest`; branches are covered by `pull_request`. `build` already carried `if: github.ref == 'refs/heads/main' && github.event_name == 'push'`, so it is untouched.

Accepted consequence: a branch pushed **without** a pull request is no longer tested. `main` is protected and requires a pull request, so nothing reaches it untested.

## 2. Nothing cancelled superseded runs

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Three pushes in quick succession ran three complete suites in parallel, two of them for commits that were no longer the tip.

## 3. `helm-test` fired on Markdown-only changes

```yaml
helm:
  - 'scripts/helm/**'          # matches scripts/helm/gimme/README.md
```

On #76 — documentation only — `helm-test` installed Helm, installed the helm-unittest plugin and rendered the chart to validate a Markdown file. A README cannot break a template.

Fixed with a negation, which `dorny/paths-filter` supports:

```yaml
helm:
  - 'scripts/helm/**'
  - '!scripts/helm/**/*.md'
  - '.github/workflows/**'
```

Unlike the first two, **this one is a defect in #74 as merged**, not a pre-existing problem.

## Verification

CI behaviour is only observable in CI. This pull request touches `.github/workflows/**`, which every filter includes, so it deliberately runs everything.

What to look for here:

1. **one run, not two** — the visible proof of fix 1, since this branch has an open pull request
2. all jobs run, because the workflow file matches every filter

What it cannot show, and is worth a throwaway branch afterwards:

3. a pull request touching only `scripts/helm/**/*.md` → `helm-test` **Skipped**, `markdown` running
4. a pull request touching a Helm template → `helm-test` still runs, guarding against the negation being too greedy

## Note

Opened from `main`, so it does not include #76. The two do not overlap — #76 touches only Markdown, this touches only the workflow — but #76 was the pull request that exposed all three defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)