### PR TITLE
ci: fix the helm path filter, which matched nearly every file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,10 @@
 name: Docker Image CI
 
 on:
-  # Only main on push: the build job publishes :latest from there. Branches are
-  # covered by pull_request — listening to both on every branch ran two full
-  # pipelines per commit, on the same SHA.
   push:
     branches: [ main ]
   pull_request:
 
-# A new push supersedes the run in flight for the same ref; nobody reads the
-# result of a run for a commit that is no longer the tip.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -33,15 +28,12 @@ jobs:
               - 'go.sum'
               - 'Makefile'
               - '.golangci.yml'
-              # Fixtures the suite loads by path: test/test.zip, test/config/.
-              - 'test/**'
-              # Templates rendered by the api/ tests.
-              - 'templates/**'
+              - 'test/**'          # fixtures loaded by path
+              - 'templates/**'     # rendered by the api/ tests
               - '.github/workflows/**'
             helm:
-              - 'scripts/helm/**'
-              # A README cannot break a template — it belongs to the docs filter.
-              - '!scripts/helm/**/*.md'
+              # One extglob, not a '!' entry: patterns here are OR-ed.
+              - 'scripts/helm/**/!(*.md)'
               - '.github/workflows/**'
             docs:
               - '**/*.md'
@@ -168,16 +160,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Lint Markdown
-        # No globs here: .markdownlint-cli2.jsonc carries them, and command-line
-        # arguments would override it — CI and local runs must lint the same set.
+        # No globs: .markdownlint-cli2.jsonc carries them, args would override it.
         run: npx --yes markdownlint-cli2
 
   build:
     needs: [changes, test, helm-test, lint]
-    # always() is required so a skipped dependency does not skip the build, but
-    # it also defeats the implicit "all needs succeeded" guard — hence the
-    # explicit checks. `changes` must have succeeded: if it fails, every other
-    # job is skipped, and without this the image would publish untested.
+    # always() tolerates skipped needs, but also defeats the implicit
+    # "all succeeded" guard — hence the explicit result checks.
     if: >-
       always() &&
       needs.changes.result == 'success' &&


### PR DESCRIPTION
Follow-up to #78 (issue #77, item 3). The negation I merged there was wrong, and worse than the defect it replaced.

```yaml
helm:
  - 'scripts/helm/**'
  - '!scripts/helm/**/*.md'
```

Patterns in a `paths-filter` list are **OR-ed**. The second entry matches every file that is *not* chart Markdown — `TODO.md`, `README.md`, any `.go` file — so the filter went from "too generous" to "always true". `helm-test` would have run on every pull request.

## How it surfaced

#76 was rebased onto #78 expecting `helm-test` to report *Skipped*. It ran anyway, on a branch touching only Markdown. That is what prompted checking the pattern instead of trusting it.

## Verified with picomatch, which paths-filter uses

```
['scripts/helm/**', '!scripts/helm/**/*.md']
  MATCH  scripts/helm/gimme/README.md
  MATCH  TODO.md
  MATCH  README.md
  MATCH  scripts/helm/gimme/templates/deployment.yaml

['scripts/helm/**/!(*.md)']
  no     scripts/helm/gimme/README.md
  no     scripts/helm/README.md
  no     TODO.md
  MATCH  scripts/helm/gimme/templates/deployment.yaml
  MATCH  scripts/helm/gimme/values.yaml
  MATCH  scripts/helm/gimme/Chart.yaml
  MATCH  scripts/helm/gimme/templates/_helpers.tpl
  MATCH  scripts/helm/gimme/tests/deployment_test.yaml
```

A single extglob expresses the exclusion *inside* one pattern, so there is no OR to defeat it. Checked against all 20 tracked files under `scripts/helm/`: every one matches except `README.md`.

## Why the first attempt looked right

The negation reads naturally and is how `.gitignore` behaves — later patterns override earlier ones there. `paths-filter` has no such ordering: a file is in the filter if **any** pattern matches, and a negated pattern is just another pattern that happens to match the complement. Nothing warns about it, and on #78 every job ran regardless because the branch touched `.github/workflows/**`, which all filters include.

## Comment cleanup

This also trims the workflow comments — the ones added here and in #74 and #77 — from 19 lines to 5. They had grown into an explanation of *why* each decision was taken, which is what pull requests are for; the file should read as configuration.

What is kept is the three traps a reader cannot deduce from the YAML:

| Kept | Because |
|---|---|
| `# One extglob, not a '!' entry: patterns here are OR-ed.` | the subject of this PR — someone will otherwise "simplify" it back |
| `# No globs: .markdownlint-cli2.jsonc carries them, args would override it.` | adding globs silently desynchronises CI from local runs |
| `# always() tolerates skipped needs, but also defeats the implicit "all succeeded" guard` | removing the explicit result checks would publish untested images |

## Verification

This pull request touches `.github/workflows/**`, so all jobs run here too — it cannot demonstrate its own fix. Note that `markdown` reports *Skipped*, since it touches no `.md`: the filtering works in both directions.

The real check is on #76 once rebased again: `helm-test` must report **Skipped** on that Markdown-only branch, with `markdown` running.

The opposite case — a pull request touching a Helm template still running `helm-test` — is covered by the pattern table above rather than by CI observation alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)