### PR TITLE
fix: make garage-start read the node ID on BSD grep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,12 @@ garage-start:
 		echo "  attempt $$i/15..."; \
 		sleep 2; \
 	done
-	@NODE_ID=$$(docker exec $(GARAGE_CONTAINER) /garage status | grep -oP '[0-9a-f]{16}' | head -1) && \
+	@NODE_ID=$$(docker exec $(GARAGE_CONTAINER) /garage status | grep -oE '[0-9a-f]{16}' | head -1) && \
+		if [ -z "$$NODE_ID" ]; then \
+			echo "ERROR: could not read the Garage node ID"; \
+			docker logs $(GARAGE_CONTAINER); \
+			exit 1; \
+		fi && \
 		docker exec $(GARAGE_CONTAINER) /garage layout assign -z dc1 -c 1G "$$NODE_ID" && \
 		docker exec $(GARAGE_CONTAINER) /garage layout apply --version 1 && \
 		docker exec $(GARAGE_CONTAINER) /garage key create gimme-key && \

--- a/TODO.md
+++ b/TODO.md
@@ -82,7 +82,7 @@ One-line fixes, no dependencies, no behaviour change.
   *Files:* `go.mod`, Go imports, coverage filters, `CONTRIBUTING.md`, `CLAUDE.md`
   *Watch:* the coverage filters in `Makefile` and `.github/workflows/build.yml` match the module path as a literal string. Miss one and it silently stops excluding `test/mocks` — nothing turns red.
 
-- [ ] **#73 — `make garage-start`: `grep -oP` is not portable, `NODE_ID` is empty on macOS**
+- [x] **#73 — `make garage-start`: `grep -oP` is not portable, `NODE_ID` is empty on macOS**
   `Makefile:102` uses `grep -oP`, a GNU extension that BSD grep rejects. `NODE_ID` ends up empty and `garage layout assign` silently matches the only node by empty prefix. Replace it with `-oE` and add a non-empty guard.
   *Files:* `Makefile`
   *Independent of everything else.*


### PR DESCRIPTION
Closes #73.

`Makefile:102` extracted the Garage node ID with a PCRE-only flag:

```make
@NODE_ID=$$(docker exec $(GARAGE_CONTAINER) /garage status | grep -oP '[0-9a-f]{16}' | head -1) && \
```

`grep -P` is a GNU extension. macOS ships BSD grep, which rejects it:

```
$ echo "Node ID: 4c504e072135a35d" | /usr/bin/grep -oP '[0-9a-f]{16}'
grep: invalid option -- P
exit=2
```

## Why it still worked, which is the actual defect

The layout was applied regardless:

```
$ NODE_ID=$(docker exec gimme-garage-test /garage status | /usr/bin/grep -oP '[0-9a-f]{16}' | head -1)
grep: invalid option -- P
NODE_ID=''

$ docker exec gimme-garage-test /garage layout show
ID                Tags  Zone  Capacity   Usable capacity
1c9dd7924d44392f        dc1   1000.0 MB  1000.0 MB (100.0%)
```

`garage layout assign` matches node IDs **by prefix**, and an empty prefix matches every node. Confirmed directly:

```
$ docker exec gimme-garage-test /garage layout assign -z dc1 -c 1G ""
Role changes are staged but not yet committed.
```

The test cluster has exactly one node, so "every node" and "the right node" were the same thing. The selection was accidental, and stops being equivalent the day the fixture gains a second node.

## Fix

`-oE` is POSIX and gives identical output for this pattern, plus a guard so an empty ID fails the target instead of assigning by accident.

## Evidence

Shell output, as in #58 — a Makefile target has no unit test. `TODO.md` names this form under *Prove it*.

**Before:**

```
$ make garage-start
Waiting for Garage to be ready...
  attempt 1/15...
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] ...
NODE_ID=''
```

**After:**

```
$ make garage-start
Garage ready.
NODE_ID='7bf4126d310f2a97'

$ docker exec gimme-garage-test /garage layout show
ID                Tags  Zone  Capacity   Usable capacity
7bf4126d310f2a97        dc1   1000.0 MB  1000.0 MB (100.0%)
```

The node is now assigned by its actual ID rather than matched by an empty prefix.

The guard was exercised both ways: empty `NODE_ID` reaches the error branch and exits 1; a populated one passes through to `layout assign`.

## Quality gate

Run through a Sonnet agent, raw output:

| Check | Result |
|---|---|
| `gofmt -l .` | exit 0, empty |
| `golangci-lint run ./...` | exit 0 — `0 issues` |
| `make test` | exit 0, all packages `ok`, **and no `grep: invalid option` in the output** |
| `make build` | exit 0 |
| `npx markdownlint-cli2` | exit 0 — `0 issues in 10 files` |

## Not touched

The same `grep -oP` exists at `.github/workflows/build.yml:47`, where it runs on Linux with GNU grep and works — and where an empty ID is already caught by an explicit check. Left alone deliberately; CI behaviour is unchanged by this PR.

## Note

Found while reading the raw output of `make test` during #72. It is invisible in a summarised run: the target succeeds, so nothing draws attention to the error text scrolling past.

🤖 Generated with [Claude Code](https://claude.com/claude-code)