### PR TITLE
fix: bound upload concurrency in CreatePackage (#44)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -123,7 +123,7 @@ Before touching application code, so the lint inventory is known in advance.
 
 **Do these while there is no known production usage.** Four of them change behaviour in ways that would need a deprecation path once real deployments exist.
 
-- [ ] **#44 — `errgroup` has no concurrency limit**
+- [x] **#44 — `errgroup` has no concurrency limit**
   One line: `eg.SetLimit(...)`. Land it first — it clears the upload path before the larger changes.
   *Files:* `internal/content/content-service.go`
   *Prove it:* the hardest one to red-test. Instrument the mock's `AddObject` with an atomic counter tracking peak concurrency, upload an archive with many entries, assert the peak stays at or below the limit. Before the fix the peak equals the entry count; after, it is capped.

--- a/internal/content/content-service.go
+++ b/internal/content/content-service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -111,6 +112,8 @@ func (svc *ContentService) CreatePackage(ctx context.Context, name string, versi
 	}
 
 	var eg errgroup.Group
+	// Bound concurrency so resource use does not grow unbounded with archive entry count.
+	eg.SetLimit(runtime.NumCPU() * 4)
 
 	for _, currentFile := range archive.File {
 		eg.Go(func() error {

--- a/internal/content/content-service_test.go
+++ b/internal/content/content-service_test.go
@@ -1,8 +1,13 @@
 package content
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"fmt"
 	"os"
+	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -279,4 +284,62 @@ func TestIsPinnedVersion(t *testing.T) {
 			assert.Equal(t, tt.expected, IsPinnedVersion(tt.version))
 		})
 	}
+}
+
+// --- Upload concurrency tests ---
+
+// concurrencyTrackingOSManager records the peak number of AddObject calls in
+// flight at any moment, plus the total number of calls.
+type concurrencyTrackingOSManager struct {
+	*mocks.MockOSManager
+	inFlight atomic.Int64
+	peak     atomic.Int64
+	calls    atomic.Int64
+}
+
+func (osc *concurrencyTrackingOSManager) AddObject(_ context.Context, _ string, _ *zip.File) *errors.GimmeError {
+	osc.calls.Add(1)
+	current := osc.inFlight.Add(1)
+	for {
+		peak := osc.peak.Load()
+		if current <= peak || osc.peak.CompareAndSwap(peak, current) {
+			break
+		}
+	}
+	// Hold the slot long enough for every concurrent upload to overlap.
+	time.Sleep(10 * time.Millisecond)
+	osc.inFlight.Add(-1)
+	return nil
+}
+
+// buildArchive builds an in-memory zip archive holding entries files.
+func buildArchive(t *testing.T, entries int) (*bytes.Reader, int64) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := zip.NewWriter(&buf)
+	for i := range entries {
+		entry, err := writer.Create(fmt.Sprintf("root/file-%d.js", i))
+		require.NoError(t, err)
+		_, err = entry.Write([]byte("content"))
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close())
+
+	return bytes.NewReader(buf.Bytes()), int64(buf.Len())
+}
+
+func TestContentService_CreatePackage_LimitsConcurrency(t *testing.T) {
+	limit := runtime.NumCPU() * 4
+	entries := limit + 50
+
+	manager := &concurrencyTrackingOSManager{MockOSManager: &mocks.MockOSManager{}}
+	service := NewContentService(manager, nil, 0)
+
+	reader, size := buildArchive(t, entries)
+	err := service.CreatePackage(context.Background(), "test", "1.0.0", reader, size)
+	require.Nil(t, err)
+
+	assert.Equal(t, int64(entries), manager.calls.Load(), "every archive entry must be uploaded")
+	assert.LessOrEqual(t, manager.peak.Load(), int64(limit), "concurrent uploads must stay at or below the limit")
 }


### PR DESCRIPTION
Closes #44.

## Problem

`CreatePackage` ran every ZIP entry through an `errgroup.Group` with no `SetLimit` — one goroutine and one in-flight `PutObject` per entry, no ceiling. Resource consumption grew proportional to user-controlled input: a design-system bundle with 5000 icons issues 5000 concurrent `PutObject` calls. The pressure lands on the minio-go transport connection pool and the S3 backend's own concurrency limits.

## Fix

```go
var eg errgroup.Group
// Bound concurrency so resource use does not grow unbounded with archive entry count.
eg.SetLimit(runtime.NumCPU() * 4)
```

No new config key, no new error path, no product decision. Upload size, entry count and decompressed-size limits stay out of scope — that is #62.

## Proof: red before green

`TestContentService_CreatePackage_LimitsConcurrency` instruments a mock `AddObject` with an atomic peak-concurrency counter and uploads an archive of `NumCPU*4+50` entries.

Before the fix (10-CPU machine → limit 40, 90 entries):

```text
=== RUN   TestContentService_CreatePackage_LimitsConcurrency
    content-service_test.go:344:
        	Error:      	"90" is not less than or equal to "40"
        	Test:       	TestContentService_CreatePackage_LimitsConcurrency
        	Messages:   	concurrent uploads must stay at or below the limit
--- FAIL: TestContentService_CreatePackage_LimitsConcurrency (0.01s)
FAIL	github.com/ziggornif/gimme/internal/content	0.522s
```

Peak equals the entry count — unbounded, as described. After the fix, `-count=3`:

```text
--- PASS: TestContentService_CreatePackage_LimitsConcurrency (0.04s)
--- PASS: TestContentService_CreatePackage_LimitsConcurrency (0.04s)
--- PASS: TestContentService_CreatePackage_LimitsConcurrency (0.04s)
ok  	github.com/ziggornif/gimme/internal/content	0.606s
```

The test also asserts every entry is still uploaded, so the bound cannot pass by dropping work.

## Quality gate

| Check | Result |
|---|---|
| `gofmt -l .` | no output |
| `golangci-lint run ./...` (v2.12.2) | 0 issues |
| `make test` | exit 0 — `internal/content` 95.4%, `api` 86.5% |
| `make build` | exit 0 |

`TODO.md` ticked in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Measured end-to-end after review

The issue notes the failure threshold was never reproduced. It has been now, on a real S3 backend.

**Setup.** `@mui/icons-material@5.15.21` → zip of **31 843 files**, 23.5 MB. Garage v1.3.1, restarted clean between the two runs. `main` (86de7f5) vs this branch, same archive, same host. Sampling every 0.5 s: `go_goroutines` from `/metrics`, sockets from `lsof -p PID -i TCP`, RSS from `ps`.

| | without the fix (`main`) | with the fix |
|---|---|---|
| Upload outcome | **never completed** — killed at ~9 min | **HTTP 201 in 13.5 s** |
| Goroutines (idle: 11) | `/metrics` never answered | **140** peak |
| TCP sockets (idle: 3) | **46 164** peak | **89** peak |
| RSS (idle: 24 MB) | 1.44 → 2.29 → 3.62 → 4.88 → **5.71 GB**, still climbing | **127 MB**, flat |
| `/healthz` during upload | **HTTP 000**, 10 s timeout, 3 attempts | HTTP 200 in ~17 ms |
| `/metrics` during upload | 5 s timeout on every sample | HTTP 200 in 15 ms |
| Errors logged | 0 | 0 |

After the fixed run: Garage holds **31 843 objects** (18.7 MB) — exactly the entry count — and `GET /gimme/mui-icons@5.15.21/esm/Abc.js` returns 200.

**It does not crash — it starves.** No error is logged on either side, Garage stays up, nothing panics. The operational symptom is `/healthz` going unanswered: with the chart's default probes (`periodSeconds: 10`, `failureThreshold: 3`) Kubernetes kills the pod after ~30 s, mid-upload. On restart `ObjectExists` sees the half-written prefix and returns **409 Conflict**, so the package is stuck — neither complete nor re-uploadable.

That is the case for landing this beyond hygiene.
