### PR TITLE
fix: resolve partial versions and file names structurally (#45, #46)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -146,7 +146,8 @@ Before touching application code, so the lint inventory is known in advance.
   Same function, same test table. `pkg@1` currently resolves to `10.0.0`; `/app.js` also matches `app.js.map`.
   *Files:* `internal/content/content-service.go`, `internal/content/content-service_test.go`, **`test/mocks/objectstorage-manager.go`**
   ⚠️ **The mock fixture must change or the tests stay green and prove nothing.** It holds only `1.0.0`/`1.1.0`/`1.1.1` — no two-digit components, one major — and filters with `Contains` instead of prefix matching, reproducing the bug it should catch.
-  *Prove it:* **fixture first.** Add `1.9.9`, `10.0.0`, `1.10.0` and switch the mock to prefix filtering, then run the existing suite — `TestContentService_GetMajorFile` should now fail, which is the red step. Only then write the component-wise comparison. If the suite still passes after the fixture change, the fixture change was wrong.
+  *Prove it:* **fixture first.** Add `1.9.9`, `10.0.0`, `1.10.0` and switch the mock to prefix filtering, then run the existing suite. Only then write the component-wise comparison.
+  ⚠️ *Correction, measured 2026-08-03 — the fixture change alone does **not** turn the suite red.* It was tried (added `1.9.9`, `1.10.0`, `1.11.0`, `10.0.0`, swapped `Contains` for `HasPrefix`) and everything stayed green. `TestContentService_GetMajorFile` asserts only `NotNil(file)` / `Nil(err)`, and `MockOSManager.GetObject` returns a `&minio.Object{}` for **any** path — so `@1` resolving to `10.0.0` raises nothing. The red step therefore needs a **third change**: a mock that records the resolved key, plus assertions on that key (`@1` → `test@1.11.0/test.js`, not `test@10.0.0/test.js`; `test.js` must not match `test.js.map`). Fixture + prefix filtering are necessary, not sufficient.
 
 > **Placeholder policy — applies to #59 and #60.** Demonstration stacks must start; a real installation must not run with a published secret.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -142,7 +142,7 @@ Before touching application code, so the lint inventory is known in advance.
   *Note:* symptom 4 most likely comes from the unbounded `errgroup` in #44, which lands first. Fixing #44 makes the collision deterministic; only this task makes it impossible.
   *Settled while implementing:* dot-prefixed segments (`.well-known/probe.txt`, `.hidden/x.js`) are **accepted and namespaced**, not rejected — they are legitimate asset paths, and the whitelist rule (key must start with `<pkg>@<version>/`) already contains them. Rejection is reserved for empty names, absolute paths, `..` escapes and duplicate target keys, and it applies to the **whole archive** — never a silently skipped entry.
 
-- [ ] **#45 + #46 — Version and filename resolution** ⚠️ *ship together*
+- [x] **#45 + #46 — Version and filename resolution** ⚠️ *ship together*
   Same function, same test table. `pkg@1` currently resolves to `10.0.0`; `/app.js` also matches `app.js.map`.
   *Files:* `internal/content/content-service.go`, `internal/content/content-service_test.go`, **`test/mocks/objectstorage-manager.go`**
   ⚠️ **The mock fixture must change or the tests stay green and prove nothing.** It holds only `1.0.0`/`1.1.0`/`1.1.1` — no two-digit components, one major — and filters with `Contains` instead of prefix matching, reproducing the bug it should catch.

--- a/internal/content/content-service.go
+++ b/internal/content/content-service.go
@@ -43,10 +43,37 @@ func NewContentService(objectStorageManager storage.ObjectStorageManager, cacheM
 }
 
 // filterArray filter objects array
-func (svc *ContentService) filterArray(arr []minio.ObjectInfo, fileName string, version string) []minio.ObjectInfo {
+func (svc *ContentService) filterArray(arr []minio.ObjectInfo, pkg string, fileName string, version string) []minio.ObjectInfo {
 	var filtered []minio.ObjectInfo
+	packagePrefix := fmt.Sprintf("%s@", pkg)
+	partialVersion := len(strings.Split(version, ".")) < 3
+
 	for _, item := range arr {
-		if strings.Contains(item.Key, fileName) && strings.Contains(item.Key, version) {
+		keyWithoutPackage, found := strings.CutPrefix(item.Key, packagePrefix)
+		if !found {
+			continue
+		}
+
+		candidateVersion, candidateFile, found := strings.Cut(keyWithoutPackage, "/")
+		if !found || "/"+candidateFile != fileName {
+			continue
+		}
+
+		candidateSemver := "v" + candidateVersion
+		if !semver.IsValid(candidateSemver) {
+			continue
+		}
+
+		matchesVersion := candidateVersion == version
+		if partialVersion && semver.Prerelease(candidateSemver) == "" {
+			switch len(strings.Split(version, ".")) {
+			case 1:
+				matchesVersion = semver.Major(candidateSemver) == "v"+version
+			case 2:
+				matchesVersion = semver.MajorMinor(candidateSemver) == "v"+version
+			}
+		}
+		if matchesVersion {
 			filtered = append(filtered, item)
 		}
 	}
@@ -73,19 +100,20 @@ func (svc *ContentService) getLatestVersion(arr []minio.ObjectInfo) string {
 		if v == "" {
 			continue // skip malformed entries
 		}
-		versions = append(versions, v)
+		versions = append(versions, "v"+v)
 	}
 	if len(versions) == 0 {
 		return ""
 	}
 	semver.Sort(versions)
-	return versions[len(versions)-1]
+	return strings.TrimPrefix(versions[len(versions)-1], "v")
 }
 
 // getLatestPackagePath get latest package path
 func (svc *ContentService) getLatestPackagePath(ctx context.Context, pkg string, version string, fileName string) string {
+	fileName = "/" + strings.TrimLeft(fileName, "/")
 	objs := svc.objectStorageManager.ListObjects(ctx, fmt.Sprintf("%s@%s", pkg, version))
-	filtred := svc.filterArray(objs, fileName, version)
+	filtred := svc.filterArray(objs, pkg, fileName, version)
 
 	if len(filtred) == 0 {
 		return fmt.Sprintf("%s@%s%s", pkg, version, fileName)

--- a/internal/content/content-service_test.go
+++ b/internal/content/content-service_test.go
@@ -75,24 +75,63 @@ func TestContentService_GetFileSemverErr(t *testing.T) {
 }
 
 func TestContentService_GetFile(t *testing.T) {
-	service := NewContentService(&mocks.MockOSManager{}, nil, 0)
-	file, err := service.GetFile(context.Background(), "test", "1.1.1", "test.js")
+	osm := &mocks.MockOSManager{}
+	service := NewContentService(osm, nil, 0)
+	file, err := service.GetFile(context.Background(), "test", "1.1.1", "/test.js")
 	assert.NotNil(t, file)
 	assert.Nil(t, err)
+	assert.Equal(t, "test@1.1.1/test.js", osm.LastGetObjectPath())
 }
 
+// Partial versions must be compared component-wise: 1.10.0 is newer than 1.9.9,
+// and 10.0.0 is a different major that pkg@1 must never resolve to.
 func TestContentService_GetMajorFile(t *testing.T) {
-	service := NewContentService(&mocks.MockOSManager{}, nil, 0)
-	file, err := service.GetFile(context.Background(), "test", "1", "test.js")
+	osm := &mocks.MockOSManager{}
+	service := NewContentService(osm, nil, 0)
+	file, err := service.GetFile(context.Background(), "test", "1", "/test.js")
 	assert.NotNil(t, file)
 	assert.Nil(t, err)
+	assert.Equal(t, "test@1.10.0/test.js", osm.LastGetObjectPath())
 }
 
 func TestContentService_GetMinorFile(t *testing.T) {
-	service := NewContentService(&mocks.MockOSManager{}, nil, 0)
-	file, err := service.GetFile(context.Background(), "test", "1.1", "test.js")
+	osm := &mocks.MockOSManager{}
+	service := NewContentService(osm, nil, 0)
+	file, err := service.GetFile(context.Background(), "test", "1.1", "/test.js")
 	assert.NotNil(t, file)
 	assert.Nil(t, err)
+	// 1.1 must not swallow 1.10.0 or 1.11.0.
+	assert.Equal(t, "test@1.1.1/test.js", osm.LastGetObjectPath())
+}
+
+// A partial version must resolve to a stable release only: 2.0.0-rc.1 is not
+// what pkg@2 promises.
+func TestContentService_GetFile_PartialVersionSkipsPrerelease(t *testing.T) {
+	osm := &mocks.MockOSManager{}
+	service := NewContentService(osm, nil, 0)
+	_, err := service.GetFile(context.Background(), "test", "2", "/test.js")
+	assert.Nil(t, err)
+	assert.Equal(t, "test@2/test.js", osm.LastGetObjectPath())
+}
+
+// A file name must match a whole path segment: test.js must not be satisfied by
+// test.js.map, and asking for the map must reach the version that holds it.
+func TestContentService_GetFile_FileNameIsNotASubstringMatch(t *testing.T) {
+	osm := &mocks.MockOSManager{}
+	service := NewContentService(osm, nil, 0)
+
+	file, err := service.GetFile(context.Background(), "test", "1.11", "/test.js.map")
+	assert.NotNil(t, file)
+	assert.Nil(t, err)
+	assert.Equal(t, "test@1.11.0/test.js.map", osm.LastGetObjectPath())
+
+	// 1.11.0 holds no test.js, only test.js.map: nothing resolves, so the
+	// unresolved partial version is queried and the storage answers 404.
+	osm = &mocks.MockOSManager{}
+	service = NewContentService(osm, nil, 0)
+	_, err = service.GetFile(context.Background(), "test", "1.11", "/test.js")
+	assert.Nil(t, err)
+	assert.Equal(t, "test@1.11/test.js", osm.LastGetObjectPath())
 }
 
 func TestContentService_GetFiles(t *testing.T) {

--- a/test/mocks/objectstorage-manager.go
+++ b/test/mocks/objectstorage-manager.go
@@ -10,7 +10,20 @@ import (
 	"github.com/minio/minio-go/v7"
 )
 
-type MockOSManager struct{}
+type MockOSManager struct {
+	// GetObjectPaths records every key GetObject was asked for, so tests can
+	// assert on the path version resolution produced — not merely that some
+	// object came back.
+	GetObjectPaths []string
+}
+
+// LastGetObjectPath returns the last key passed to GetObject, or "" if it was never called.
+func (osc *MockOSManager) LastGetObjectPath() string {
+	if len(osc.GetObjectPaths) == 0 {
+		return ""
+	}
+	return osc.GetObjectPaths[len(osc.GetObjectPaths)-1]
+}
 
 func (osc *MockOSManager) CreateBucket(_ context.Context, _ string, _ string) *errors.GimmeError {
 	return nil
@@ -18,7 +31,8 @@ func (osc *MockOSManager) CreateBucket(_ context.Context, _ string, _ string) *e
 func (osc *MockOSManager) AddObject(_ context.Context, _ string, _ *zip.File) *errors.GimmeError {
 	return nil
 }
-func (osc *MockOSManager) GetObject(_ context.Context, _ string) (*minio.Object, *errors.GimmeError) {
+func (osc *MockOSManager) GetObject(_ context.Context, objectPath string) (*minio.Object, *errors.GimmeError) {
+	osc.GetObjectPaths = append(osc.GetObjectPaths, objectPath)
 	return &minio.Object{}, nil
 }
 
@@ -27,6 +41,10 @@ func (osc *MockOSManager) ObjectExists(_ context.Context, _ string) bool {
 }
 
 func (osc *MockOSManager) ListObjects(_ context.Context, fileName string) []minio.ObjectInfo {
+	// Two-digit components (1.10.0, 1.11.0) and a second major (10.0.0) are
+	// required: without them no fixture can express the pkg@1 -> 10.0.0 bug.
+	// 1.11.0 deliberately ships only a source map, so a request for test.js
+	// must not resolve to it.
 	var objs = []minio.ObjectInfo{{
 		Key: "test@1.0.0",
 	}, {
@@ -39,12 +57,34 @@ func (osc *MockOSManager) ListObjects(_ context.Context, fileName string) []mini
 		Key: "test@1.1.1",
 	}, {
 		Key: "test@1.1.1/test.js",
+	}, {
+		Key: "test@1.9.9",
+	}, {
+		Key: "test@1.9.9/test.js",
+	}, {
+		Key: "test@1.10.0",
+	}, {
+		Key: "test@1.10.0/test.js",
+	}, {
+		Key: "test@1.11.0",
+	}, {
+		Key: "test@1.11.0/test.js.map",
+	}, {
+		Key: "test@10.0.0",
+	}, {
+		Key: "test@10.0.0/test.js",
+	}, {
+		// Only pre-release in the 2.x line: pkg@2 must not resolve to it.
+		Key: "test@2.0.0-rc.1",
+	}, {
+		Key: "test@2.0.0-rc.1/test.js",
 	}}
 
+	// Object storages list by prefix, not by substring.
 	if len(fileName) > 0 {
 		var filtered []minio.ObjectInfo
 		for _, item := range objs {
-			if strings.Contains(item.Key, fileName) {
+			if strings.HasPrefix(item.Key, fileName) {
 				filtered = append(filtered, item)
 			}
 		}


### PR DESCRIPTION
Fixes #45. Fixes #46.

## Problem

`filterArray` matched both the version and the file name with `strings.Contains`:

- `pkg@1` resolved to `10.0.0` — object storage lists `pkg@10.0.0` under the prefix `pkg@1`, and `Contains(key, "1")` kept it
- `pkg@1.1` swallowed `1.10.0` and `1.11.0`
- `/app.js` was satisfied by `app.js.map`, so resolution could land on a version that does not hold the file and 404

## Fix

`internal/content/content-service.go` only:

- the key is split into package / version / file instead of being scanned for substrings
- versions compared component-wise (`semver.Major` / `semver.MajorMinor`), pre-releases excluded from partial resolution, non-semver candidates skipped
- the file name must equal the whole remainder of the key
- unchanged fallback when nothing matches: `<pkg>@<requestedVersion><fileName>`, answered 404 by the storage
- `getLatestVersion` fed `semver.Sort` unprefixed versions, which is not valid semver input — now prefixed with `v` before sorting and trimmed after

## Failing tests first

The fixture could not express either bug: one major, no two-digit component, `Contains` filtering, and a mock returning an object for any path. It now mirrors object-storage prefix semantics and records the resolved key.

Red before the fix:

```
--- FAIL: TestContentService_GetMajorFile
    expected: "test@1.10.0/test.js"
    actual  : "test@10.0.0/test.js"
--- FAIL: TestContentService_GetMinorFile
    expected: "test@1.1.1/test.js"
    actual  : "test@1.11.0/test.js"
--- FAIL: TestContentService_GetFile_PartialVersionSkipsPrerelease
    expected: "test@2/test.js"
    actual  : "test@2.0.0-rc.1/test.js"
--- FAIL: TestContentService_GetFile_FileNameIsNotASubstringMatch
    expected: "test@1.11/test.js"
    actual  : "test@1.11.0/test.js"
```

## Verified against a live Garage

Two local instances, same bucket: `main` vs this branch.

| Request | before | after |
|---|---|---|
| `demo@1/app.js` (1.0.0, 1.9.9, 1.10.0, 10.0.0) | 200 → `demo 10.0.0` | 200 → `demo 1.10.0` |
| `mapdemo@1/app.js` (1.11.0 ships only `app.js.map`) | 404 | 200 → `mapdemo 1.10.0` |
| `rcdemo@2/app.js` (only `2.0.0-rc.1`) | 200 → pre-release | 404 |
| `demo@1.9/app.js` | 200 → `1.9.9` | 200 → `1.9.9` |

## Checks

`gofmt -l .` empty · `golangci-lint run ./...` 0 issues · `make test` all packages ok (`internal/content` 95.3%) · `make build` ok

Also ticks `#45 + #46` in `TODO.md`, and corrects the TODO recipe: the fixture change alone leaves the suite green — the mock had to record the resolved key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
