### PR TITLE
fix: placeholder secrets — the install template must fail, the demo stacks must start (#59, #60)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -159,7 +159,7 @@ Before touching application code, so the lint inventory is known in advance.
 >
 > No application code either way. The existing 32-byte check does the work — the placeholder value decides the outcome.
 
-- [ ] **#59 — `gimme.example.yml` placeholder secret passes validation**
+- [x] **#59 — `gimme.example.yml` placeholder secret passes validation**
   The placeholder says "at least 32 chars" and is 50 characters long, so it satisfies its own instruction and forces nothing. A user who edits only the S3 block runs with a secret published in this repo — which derives the token-file AES key and the OIDC session signing key.
   *Files:* `gimme.example.yml` — **no application code**
   *Fix:* short failing value, guidance moved to a comment: `# Required. Generate one with: openssl rand -hex 32` / `secret: "CHANGEME"`. Consider the same for `admin.user`/`admin.password`.

--- a/TODO.md
+++ b/TODO.md
@@ -166,7 +166,7 @@ Before touching application code, so the lint inventory is known in advance.
   *Prove it:* Go test — `NewConfig()` on `gimme.example.yml` must be **rejected**. It is accepted today; that is the red step.
   *Not breaking:* changes a shipped template, not the behaviour of a running instance.
 
-- [ ] **#60 — Compose example `with-managed-s3` cannot start**
+- [x] **#60 — Compose example `with-managed-s3` cannot start**
   `secret: secret` (6 chars) fails the 32-byte minimum, so the stack dies on a field the example never asks the user to fill. Align to the sibling `with-garage` value, which passes.
   *Files:* `examples/deployment/docker-compose/with-managed-s3/gimme.yml`
   *Prove it:* Go test — `NewConfig()` on the example file must be **accepted** as far as the secret goes. Red output today: `secret must be at least 32 bytes long (got 6)`.

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ziggornif/gimme/test/utils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func remove(src string) error {
@@ -261,4 +262,27 @@ func TestNewConfigOIDCValid(t *testing.T) {
 	assert.Equal(t, "https://keycloak.example.com/realms/gimme", confObj.Auth.OIDC.Issuer)
 	assert.Equal(t, "gimme", confObj.Auth.OIDC.ClientID)
 	assert.Equal(t, "https://gimme.example.com/auth/callback", confObj.Auth.OIDC.RedirectURL)
+}
+
+// TestNewConfigShippedExampleIsRejected asserts that the shipped installation
+// template refuses to start as-is. gimme.example.yml is copied to gimme.yml by
+// release.yml and by the "build from source" README instructions, so a user who
+// edits only the S3 block must not end up running with the placeholder secret
+// published in this repository — it derives the token-file AES key and the OIDC
+// session signing key.
+//
+// The real file is read on purpose: a fixture copy would not prove anything
+// about what ships.
+func TestNewConfigShippedExampleIsRejected(t *testing.T) {
+	utils.CopyFile("../gimme.example.yml", "./gimme.yml")
+	defer func() {
+		err := remove("./gimme.yml")
+		assert.Nil(t, err)
+	}()
+	_, err := NewConfig()
+
+	// Only the rejection is asserted, not the wording: the message is expected to
+	// change (#64 reports every invalid field at once).
+	require.NotNil(t, err, "the shipped example must not be a runnable configuration")
+	assert.Contains(t, err.Error(), "secret")
 }

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -264,15 +264,9 @@ func TestNewConfigOIDCValid(t *testing.T) {
 	assert.Equal(t, "https://gimme.example.com/auth/callback", confObj.Auth.OIDC.RedirectURL)
 }
 
-// TestNewConfigShippedExampleIsRejected asserts that the shipped installation
-// template refuses to start as-is. gimme.example.yml is copied to gimme.yml by
-// release.yml and by the "build from source" README instructions, so a user who
-// edits only the S3 block must not end up running with the placeholder secret
-// published in this repository — it derives the token-file AES key and the OIDC
-// session signing key.
-//
-// The real file is read on purpose: a fixture copy would not prove anything
-// about what ships.
+// TestNewConfigShippedExampleIsRejected asserts that the installation template
+// shipped in every release archive refuses to start as-is, so that no instance
+// runs with the placeholder secret published here.
 func TestNewConfigShippedExampleIsRejected(t *testing.T) {
 	utils.CopyFile("../gimme.example.yml", "./gimme.yml")
 	defer func() {
@@ -281,17 +275,14 @@ func TestNewConfigShippedExampleIsRejected(t *testing.T) {
 	}()
 	_, err := NewConfig()
 
-	// Only the rejection is asserted, not the wording: the message is expected to
-	// change (#64 reports every invalid field at once).
+	// The wording is not asserted: #64 will change it.
 	require.NotNil(t, err, "the shipped example must not be a runnable configuration")
 	assert.Contains(t, err.Error(), "secret")
 }
 
-// TestNewConfigManagedS3ExampleIsAccepted asserts the opposite of the test
-// above, for the opposite kind of file. The Compose examples are demonstration
-// stacks: the user is asked to supply their own storage credentials and nothing
-// else, so the stack must not die on a field the example never told them to
-// fill. The real shipped file is read here too.
+// TestNewConfigManagedS3ExampleIsAccepted asserts the opposite for a
+// demonstration stack: it must start as shipped, since the user is asked to
+// supply storage credentials and nothing else.
 func TestNewConfigManagedS3ExampleIsAccepted(t *testing.T) {
 	utils.CopyFile("../examples/deployment/docker-compose/with-managed-s3/gimme.yml", "./gimme.yml")
 	defer func() {

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -286,3 +286,20 @@ func TestNewConfigShippedExampleIsRejected(t *testing.T) {
 	require.NotNil(t, err, "the shipped example must not be a runnable configuration")
 	assert.Contains(t, err.Error(), "secret")
 }
+
+// TestNewConfigManagedS3ExampleIsAccepted asserts the opposite of the test
+// above, for the opposite kind of file. The Compose examples are demonstration
+// stacks: the user is asked to supply their own storage credentials and nothing
+// else, so the stack must not die on a field the example never told them to
+// fill. The real shipped file is read here too.
+func TestNewConfigManagedS3ExampleIsAccepted(t *testing.T) {
+	utils.CopyFile("../examples/deployment/docker-compose/with-managed-s3/gimme.yml", "./gimme.yml")
+	defer func() {
+		err := remove("./gimme.yml")
+		assert.Nil(t, err)
+	}()
+	confObj, err := NewConfig()
+
+	require.Nil(t, err, "the demonstration stack must start as shipped")
+	assert.GreaterOrEqual(t, len(confObj.Secret), 32)
+}

--- a/examples/deployment/docker-compose/with-managed-s3/gimme.yml
+++ b/examples/deployment/docker-compose/with-managed-s3/gimme.yml
@@ -2,7 +2,7 @@ admin:
   user: gimmeadmin
   password: gimmeadmin
 port: 8080
-secret: secret
+secret: change_me_use_a_real_secret_32chars
 s3:
   url: your.s3.url.cloud
   key: s3key

--- a/gimme.example.yml
+++ b/gimme.example.yml
@@ -3,7 +3,8 @@ admin:
   user: gimmeadmin
   password: gimmeadmin
 port: 8080
-secret: "CHANGE-ME-use-a-random-secret-of-at-least-32-chars"
+# Required. Generate one with: openssl rand -hex 32
+secret: "CHANGEME"
 s3:
   url: your.s3.url.cloud
   key: s3key


### PR DESCRIPTION
Closes #59. Closes #60.

Two commits, opposite directions, one policy. No application code, no change to `validateConfig` — the existing 32-byte check does the work, and only the placeholder values decide the outcome.

| Config | Role | Secret placeholder |
|---|---|---|
| `with-garage` | demo, runs as-is | passes — unchanged |
| `with-managed-s3` | demo, user supplies S3 only | **now passes** (#60) |
| `gimme.example.yml` | real install (release archive + from source) | **now fails** (#59) |

Demonstration stacks must start. A real installation must not run with a secret published in this repository.

## #59 — the shipped install template was runnable as-is

`gimme.example.yml` carried a placeholder 50 characters long, so it satisfied its own "at least 32 chars" instruction and forced nothing. `release.yml` copies that file into every release archive and the README uses it for builds from source, so a user who fills in only the S3 block — the fields they came to configure — runs with a secret that is public. That secret is the root of two derived keys: `deriveAESKey` (HKDF-SHA256) encrypting the `FileTokenStore` file, and `deriveSecret(secret, "oidc-session")` signing the OIDC session cookie.

```diff
-secret: "CHANGE-ME-use-a-random-secret-of-at-least-32-chars"
+# Required. Generate one with: openssl rand -hex 32
+secret: "CHANGEME"
```

The user still gets a complete, commented configuration file; it simply refuses to start until the secret is set, with the existing error naming the field.

## #60 — the with-managed-s3 example stack could not start

`secret: secret`, six characters, on a stack whose entire premise is that the user supplies storage credentials and nothing else. Now aligned with the sibling `with-garage` value so the two cannot drift apart.

```diff
-secret: secret
+secret: change_me_use_a_real_secret_32chars
```

## Red before green

Both tests read the **real shipped files**, not fixture copies — a copy would prove nothing about what ships.

`TestNewConfigShippedExampleIsRejected`, before the fix:

```
--- FAIL: TestNewConfigShippedExampleIsRejected (0.00s)
    config_test.go:284:
        	Error:      	Expected value not to be nil.
        	Messages:   	the shipped example must not be a runnable configuration
```

`TestNewConfigManagedS3ExampleIsAccepted`, before the fix:

```
level=error msg="NewConfig - Configuration is not valid: secret must be at least 32 bytes long (got 6)"
--- FAIL: TestNewConfigManagedS3ExampleIsAccepted (0.00s)
    config_test.go:303:
        	Error:      	Expected nil, but got: &errors.GimmeError{Kind:"InternalError", ...}
        	Messages:   	the demonstration stack must start as shipped
```

The #59 test asserts the rejection only, not the wording: #64 will change that message to report every invalid field at once.

## Quality gate

```
gofmt -l .              exit 0, no output
golangci-lint run ./... exit 0, "0 issues."
make test               exit 0, no FAIL — configs at 100% coverage, all 20 tests pass
make build              exit 0
```

## Rejected while deciding

- **A placeholder blocklist in `validateConfig`** — business logic tracking documentation artifacts, maintained in lockstep with the example files, bypassed by changing one character, and blind to the admin credentials.
- **Shipping no config file at all** — the template being present and complete is the point; it just must not be runnable.
- **Generating a secret at release time** — identical for everyone who downloads that release and published next to it.
- **Generating a secret at first start** — the operator sets the secret, gimme never invents one. It would have to be persisted on gimme's own disk, outside the operator's secret management, and each replica would generate a different one, breaking tokens and OIDC sessions across pods.

## Left for later

`admin.user` / `admin.password` are still `gimmeadmin`/`gimmeadmin` in `gimme.example.yml`. Giving them the same treatment is worth doing but pairs better with #64 — with `validateConfig` returning on the first error, three `CHANGEME` fields mean three restart-and-discover cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
