### PR TITLE
docs: spell out the v3 upgrade actions in the release plan

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -263,6 +263,13 @@ A major bump is consistent with this project's own precedent: v2 was the major f
 
 Release notes are auto-generated from PR titles in GitHub Releases. **Add a hand-written preamble for this one** listing the three breaking changes and their upgrade actions — PR titles alone will not tell an operator that their `helm upgrade` will fail, that an archive their pipeline has always uploaded is now rejected, or that a `@1` URL now serves different content.
 
+**The preamble opens with the upgrade actions, in bold, above everything else** — not at the bottom, where nobody reads them. First line: this release fixes bugs in version resolution and in how archive entries become object keys, and **it does not repair content already stored**. The fixes apply at upload and at resolution time only.
+
+There is no index to rebuild — gimme keeps none. `ListObjects` is called against S3 on every request (`internal/content/content-service.go`), so S3 is the only source of truth. The two actions are therefore:
+
+- **Re-upload the affected packages.** #42 + #43 change the object keys produced *at upload*; they rewrite nothing already in the bucket. A package uploaded from an archive without a single root folder stays flattened where it is (`img/logo.svg` stored as `pkg@1.0.0/logo.svg`), and root-level files stay orphaned outside the `<pkg>@<version>/` namespace — `DeletePackage` lists on that prefix and cannot reach them, so they survive a package deletion and need an S3 client to remove. Already-published URLs keep resolving; what stays wrong is the layout, until the package is uploaded again.
+- **Flush the Redis cache if it is enabled** (off by default). `GetFile` caches the resolution of partial versions — key `pkg@1/app.js` → resolved object path. Entries written before the upgrade encode the #45 bug (`@1` → `10.0.0`) and keep serving it until the TTL expires (3600 s by default). Pinned versions never go through the cache, so they are unaffected.
+
 ---
 
 ## Open decisions


### PR DESCRIPTION
Follow-up to #91. `TODO.md` Phase 5 asked for a hand-written preamble but listed only the breaking changes, not what an operator has to do about them.

Two actions were missing, and one wrong assumption is now written down explicitly:

- **Nothing to reindex.** gimme keeps no index — `ListObjects` runs against S3 on every request, S3 is the only source of truth. "Reindex" is the natural first guess, so the plan now says it outright.
- **Re-upload affected packages.** #42 + #43 changed the keys produced at upload; nothing already in the bucket is rewritten. Flattened files stay flattened, and root-level orphans stay outside the `<pkg>@<version>/` namespace where `DeletePackage` cannot reach them. Published URLs keep resolving — the layout is what stays wrong.
- **Flush the Redis cache if enabled** (off by default). `GetFile` caches partial-version resolution, so entries written before the upgrade keep serving the #45 bug (`@1` → `10.0.0`) until the TTL expires (3600 s default). Pinned versions bypass the cache.

The preamble is also specified to open with these actions in bold, above the rest, rather than at the bottom.

Docs only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)