### PR TITLE
fix: stop viper from reading the gimme binary as configuration (#98)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ fmt:
 
 .PHONY: build
 build:
-	go build -ldflags "-w -s" -o gimme ./cmd/server/main.go
+	go build -ldflags "-w -s" -o dist/gimme ./cmd/server/main.go
 
 # GOOS/GOARCH can be overridden on the command line or via environment variables.
 # When invoked from the Dockerfile, they are set via ARG/ENV so the build
@@ -24,8 +24,8 @@ GOARCH ?= amd64
 release:
 	rm -rf dist
 	mkdir dist
-	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-w -s" -o gimme ./cmd/server/main.go
-	cp -R gimme docs templates assets ./dist
+	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-w -s" -o dist/gimme ./cmd/server/main.go
+	cp -R docs templates assets ./dist
 
 .PHONY: test
 test: garage-start

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Requires Go 1.26+ and a running S3-compatible backend.
 ```bash
 cp gimme.example.yml gimme.yml
 # Edit gimme.yml with your S3 credentials
-make build && ./gimme
+make build && ./dist/gimme
 ```
 
 > `make build` compiles a native binary for your current OS/architecture. Use `make release` to produce a Linux/amd64 binary with `upx` compression (used by Docker and CI).

--- a/TODO.md
+++ b/TODO.md
@@ -217,6 +217,11 @@ Before touching application code, so the lint inventory is known in advance.
   *Approach:* three branches — `http.ErrMissingFile` keeps today's wording (asserted in `internal/archive_validator/archive-validator_test.go:21`), `*http.MaxBytesError` keeps the 413, anything else names its cause. Check what `mime/multipart` actually propagates before splitting parse errors from I/O errors.
   *Independent of everything else.* Small: one branch, three tests.
 
+- [x] **#98 — Env-only configuration fails from the repository root** *(found while running a live instance for #62)*
+  `SetConfigType("yaml")` makes viper accept a file named `gimme` with **no extension**, and `make build` writes the binary to exactly that path, so viper parsed 32 MB of Mach-O as YAML and the instance refused to start — defeating #61 in the one flow the README documents (`make build && ./gimme` plus `GIMME_*`). Docker was never affected: the binary is at `/bin/gimme` and the workdir holds only assets.
+  *Fixed by:* removing `SetConfigType` — nothing mounts an extension-less config, viper infers the format from the extension, and `ConfigFileNotFoundError` still fires so #61 keeps working. `make build` and `make release` now write to `dist/gimme`, which keeps a build artifact out of a config search path but is hygiene, not the fix: an operator dropping the binary next to their config directory would hit the same wall.
+  *Proved red first:* a test writing a non-YAML file named `gimme` next to the config path failed with `unable to read the config file` before the change.
+
 - [ ] **#88 — Archive shapes that produce surprising object keys without erroring** *(after #42 + #43)*
   Follow-up to #42/#43, all of it measured against `archiveKeys()`, none of it a regression — these are the archives the new code accepts while still producing keys the user did not mean.
   1. **the common-root heuristic is disarmed by a single root-level file.** `dist/app.js` + `dist/css/style.css` strips to `pkg@1.0.0/app.js`; add a `README.md` at the root and the same archive yields `pkg@1.0.0/dist/app.js` — one added file moves **every** asset URL. A Finder-made zip on macOS is therefore *never* stripped: the root-level `.DS_Store` and the `__MACOSX/` top-level segment both defeat the detection, and the junk is published inside the package.

--- a/configs/config.go
+++ b/configs/config.go
@@ -87,8 +87,9 @@ type Configuration struct {
 }
 
 func NewConfig() (*Configuration, *errors.GimmeError) {
+	// No SetConfigType: it would make viper accept an extension-less file named
+	// gimme, which is the compiled binary's own name.
 	viper.SetConfigName("gimme")
-	viper.SetConfigType("yaml")
 	viper.AddConfigPath(".")       // local path
 	viper.AddConfigPath("/config") // docker path
 	// Enable env var overrides with GIMME_ prefix.

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -499,6 +499,23 @@ func TestNewConfigEnvOnly(t *testing.T) {
 	assert.Equal(t, "file", confObj.TokenStore.Mode)
 }
 
+// The compiled binary is named gimme and lands next to the config search path,
+// so an extension-less file of that name must never be read as configuration.
+func TestNewConfigEnvOnlyIgnoresExtensionlessFile(t *testing.T) {
+	viper.Reset()
+	require.NoError(t, os.WriteFile("./gimme", []byte("\x7fELF\x02\x01\x01\x00\xff\xfe binary, not yaml"), 0o600))
+	t.Cleanup(func() {
+		assert.NoError(t, remove("./gimme"))
+		viper.Reset()
+	})
+	setRequiredEnv(t)
+
+	confObj, err := NewConfig()
+
+	require.Nil(t, err, "a file named gimme with no extension is not a config file")
+	assert.Equal(t, "envadmin", confObj.AdminUser)
+}
+
 func TestNewConfigEnvOnlyMissingField(t *testing.T) {
 	viper.Reset()
 	setRequiredEnv(t)


### PR DESCRIPTION
Closes #98.

## What was wrong

Starting gimme from the repository root with `GIMME_*` variables and no `gimme.yml` failed:

```
level=error msg="Unable to read the config file: While parsing config: yaml: invalid trailing UTF-8 octet"
unable to read the config file
```

There was no config file. What viper found was the **compiled binary**: `make build` wrote it to `./gimme`, and `NewConfig` asked for a config named `gimme` with an explicit type. `SetConfigType` is precisely what makes viper consider an extension-less file — `viper@v1.21.0/file.go:75`:

```go
for _, ext := range SupportedExts {
    if b, _ := exists(v.fs, filepath.Join(in, v.configName+"."+ext)); b { … }
}

if v.configType != "" {
    if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
        return filepath.Join(in, v.configName)   // ← 32 MB of Mach-O
    }
}
```

Since #61, a config file that exists but cannot be parsed is fatal — correct, except that the "config file" was the binary. This defeated environment-only configuration in the one flow the README documents (`make build && ./gimme` plus `GIMME_*`), which is the feature #61 shipped.

With a `gimme.yml` present, nothing happened: the extension match wins. Docker was never affected — the binary is at `/bin/gimme` and the workdir holds only `templates`, `docs` and `assets`.

## Proved red first

A test writing a non-YAML file named `gimme` next to the config search path, with the required variables set:

```
=== RUN   TestNewConfigEnvOnlyIgnoresExtensionlessFile
    Error:      Expected nil, but got: &errors.GimmeError{Kind:"InternalError", …}
    Messages:   a file named gimme with no extension is not a config file
--- FAIL: TestNewConfigEnvOnlyIgnoresExtensionlessFile (0.00s)
```

After the change it passes, logging `no config file found, relying on environment variables`.

## The fix

**`SetConfigType("yaml")` is removed.** Viper then only accepts `gimme.yml`, `gimme.yaml`, `gimme.json` and friends. Nothing depends on the extension-less form — the README, the Docker Compose examples and the Helm ConfigMap all use `/config/gimme.yml` — viper infers the format from the extension, and `SetConfigFile`, `ReadConfig` and `WriteConfig` are unused. `ConfigFileNotFoundError` is still returned when no file exists, so #61 keeps working.

**`make build` and `make release` now write to `dist/gimme`.** Hygiene rather than the fix: it keeps a build artifact out of a config search path, but an operator dropping the binary next to their configuration directory would have hit the same wall, which is why the viper change is the one that matters. `dist` was already ignored, `.air.toml` builds to `./tmp/main`, and the Dockerfile already copies `/build/dist/gimme`. `README.md` now says `make build && ./dist/gimme`.

## Verified on a live instance

Rebuilt binary, Garage backend, `./gimme` binary still sitting in the directory:

| Situation | Before | After |
|---|---|---|
| binary present, no `gimme.yml`, env-only | startup refused | `no config file found…`, `healthz=200`, `readyz=200` |
| real `gimme.yml` present | read | read — `port: 8083` from the file honoured, nothing on 8080 |
| `upload.max_entries: 4242` set in that file | — | `archive holds 5000 entries, over the limit of 4242 (upload.max_entries)` |

## Checks

| Check | Result |
|---|---|
| `gofmt -l .` | no output |
| `golangci-lint run ./...` | `0 issues.` |
| `make test` | all packages `ok` — `configs` 99.3%, `api` 87.2%, `internal/content` 94.8% |
| `make build` | `go build -ldflags "-w -s" -o dist/gimme ./cmd/server/main.go` |
| `markdownlint-cli2` | `0 issues` |

`TODO.md` records the entry in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
