### PR TITLE
feat: answer 304 Not Modified to conditional requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,8 @@ Gimme automatically emits `Cache-Control` headers on every file response, allowi
 
 **404 responses** are never cached, to avoid propagating transient misses.
 
+**Every file response also carries `ETag` and `Last-Modified`.** A cache that revalidates with `If-None-Match` — or with `If-Modified-Since`, which is consulted only when `If-None-Match` is absent — gets a `304 Not Modified` with no body when the file has not changed. That is what makes the 5-minute revalidation of a partial version cost a set of headers instead of the whole file.
+
 #### Using a reverse proxy or CDN
 
 Any HTTP cache that honours `Cache-Control` headers will work in front of gimme — Nginx, Varnish, Caddy (with the [`cache-handler`](https://github.com/caddyserver/cache-handler) plugin), Cloudflare, Fastly, etc.
@@ -534,7 +536,7 @@ Any HTTP cache that honours `Cache-Control` headers will work in front of gimme 
 Configure your proxy to cache `/gimme/*` responses and pass the `Cache-Control` header through. The headers emitted by gimme are enough to drive the caching policy:
 
 - Pinned versions (`pkg@1.0.0`) — `immutable`, safe to cache for 1 year.
-- Partial versions (`pkg@1.0`) — `max-age=300`, revalidated every 5 minutes.
+- Partial versions (`pkg@1.0`) — `max-age=300`, revalidated every 5 minutes; an unchanged file answers `304` with no body.
 - 404 / errors — `no-store`, never cached.
 
 ### Level 2 — Internal Redis cache (optional)

--- a/TODO.md
+++ b/TODO.md
@@ -259,8 +259,17 @@ Before touching application code, so the lint inventory is known in advance.
   *Library: `github.com/sabhiram/go-gitignore`, chosen on measurement* — 8 modules added to the graph against 51 for `go-git`, for the same matcher. Its support was probed rather than assumed: `*.map` at any depth, `node_modules/` at any depth, `/anchored.txt` root-only, `docs/**/*.tmp`, `!` negation, and CRLF line endings all behave. It is untagged and frozen since 2021; gitignore semantics do not change, so a frozen matcher is acceptable here.
   *Note:* #55 can filter client-side, but only for people using the CLI or the Action. This one covers hand-made zips.
 
-- [ ] **#48 — ETag / `If-None-Match` → 304**
+- [x] **#48 — ETag / `If-None-Match` → 304**
   Do before #47: smaller and self-contained, and #47 then extends it per encoding variant.
+  *Hand-rolled, not `http.ServeContent`.* `minio.Object` is an `io.ReadSeeker`, so `ServeContent` would have supplied the conditional logic for free — and Range/206 with it, which is a separate feature: a new status code, and a `Seek` on a `minio.Object` re-issues a GET against S3. The reason this task is scheduled before #47 is that it is small; taking Range along would have undone that.
+  *Precedence is an early return, not an `||`* — a present `If-None-Match` that does not match answers 200 and `If-Modified-Since` is never consulted, which is the rule that makes a stale-ETag revalidation carrying an old date behave.
+  *`LastModified` is truncated to the second before comparison.* S3 keeps sub-second precision while `Last-Modified` is second-granular, so without the truncation a client echoing back our own header looks stale on every request. Pinned by a unit case.
+  *`minio.ObjectInfo.ETag` arrives unquoted* — the header value is wrapped in `"`. A multipart upload yields a `-N` suffix instead of an MD5; it is an opaque validator either way.
+  *The `If-None-Match` list is split on `,` without honouring commas inside a quoted ETag.* S3 ETags are hex plus an optional `-N` and never contain one; a client that sends one gets a 200 with a body, never a wrong 304.
+  *304 answers pinned versions too* — `immutable` does not stop a cache from revalidating, and answering costs nothing.
+  *Tests are split, and not by preference:* `etagMatches` and `notModified` are pure functions unit-tested in `api/package-controller_test.go`, while the end-to-end 200-then-304 has to be an integration test. `MockOSManager.GetObject` returns `&minio.Object{}`, whose `Stat()` carries no ETag and no modification time — no mock fixture can express this behaviour.
+  *Left for #47:* no `Vary` header, since nothing varies yet. When brotli/gzip lands it must add `Vary: Accept-Encoding` **and** suffix the ETag per encoding variant, or a cache serves a brotli body to a client that asked for identity.
+  *Files:* `api/package-controller.go`, `api/package-controller_test.go`, `api/package-controller_integration_test.go`, `README.md`, `docs/site/index.html`, `docs/api/swagger.json`
 
 - [ ] **#47 — Serve brotli/gzip**
   Pre-compress at upload, negotiate on `Accept-Encoding`. Touches `CreatePackage`, so it must come after #42/#43.

--- a/api/package-controller.go
+++ b/api/package-controller.go
@@ -7,6 +7,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/minio/minio-go/v7"
@@ -127,6 +128,43 @@ func cacheControlHeader(version string) string {
 	return "public, max-age=300"
 }
 
+// etagMatches reports whether an If-None-Match header value matches etag.
+// Both sides are compared weakly: the W/ prefix is ignored.
+func etagMatches(ifNoneMatch string, etag string) bool {
+	if ifNoneMatch == "" || etag == "" {
+		return false
+	}
+
+	etag = strings.TrimPrefix(etag, "W/")
+	for candidate := range strings.SplitSeq(ifNoneMatch, ",") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "*" || strings.TrimPrefix(candidate, "W/") == etag {
+			return true
+		}
+	}
+
+	return false
+}
+
+// notModified reports whether the request may be answered with 304.
+func notModified(r *http.Request, etag string, lastModified time.Time) bool {
+	if ifNoneMatch := r.Header.Get("If-None-Match"); ifNoneMatch != "" {
+		return etagMatches(ifNoneMatch, etag)
+	}
+
+	ifModifiedSince := r.Header.Get("If-Modified-Since")
+	if ifModifiedSince == "" || lastModified.IsZero() {
+		return false
+	}
+
+	modifiedSince, err := http.ParseTime(ifModifiedSince)
+	if err != nil {
+		return false
+	}
+
+	return !lastModified.Truncate(time.Second).After(modifiedSince)
+}
+
 func (ctrl *PackageController) getPackage(c *gin.Context) {
 	file := c.Param("file")
 
@@ -162,7 +200,21 @@ func (ctrl *PackageController) getPackage(c *gin.Context) {
 		return
 	}
 
+	etag := ""
+	if infos.ETag != "" {
+		etag = `"` + strings.Trim(infos.ETag, `"`) + `"`
+		c.Header("ETag", etag)
+	}
+	if !infos.LastModified.IsZero() {
+		c.Header("Last-Modified", infos.LastModified.UTC().Format(http.TimeFormat))
+	}
 	c.Header("Cache-Control", cacheControlHeader(pkg.Version))
+
+	if notModified(c.Request, etag, infos.LastModified) {
+		c.Status(http.StatusNotModified)
+		return
+	}
+
 	c.DataFromReader(http.StatusOK, infos.Size, infos.ContentType, object, nil)
 }
 

--- a/api/package-controller_integration_test.go
+++ b/api/package-controller_integration_test.go
@@ -94,6 +94,43 @@ func TestPackageControllerGet(t *testing.T) {
 	_ = service.DeletePackage(context.Background(), "awesome-lib", "1.0.0") //nolint:errcheck
 }
 
+func TestPackageControllerGetConditional(t *testing.T) {
+	objectStorageManager := initObjectStorage()
+	router := gin.New()
+	authManager := newTestAuthManager(t)
+	_, rawToken, _ := authManager.CreateToken(context.Background(), "test", "")
+	service := content.NewContentService(objectStorageManager, nil, 0, content.UploadLimits{})
+	NewPackageController(router, authManager, service)
+
+	_ = createPackage(t, router, "awesome-lib", "1.0.0", "../test/test.zip", rawToken)
+
+	for _, version := range []string{"1.0.0", "1.0"} {
+		t.Run(version, func(t *testing.T) {
+			path := "/gimme/awesome-lib@" + version + "/awesome-lib.min.js"
+			first := utils.PerformRequest(router, "GET", path, nil)
+
+			assert.Equal(t, http.StatusOK, first.Code)
+			etag := first.Header().Get("ETag")
+			assert.NotEmpty(t, etag)
+			assert.NotEmpty(t, first.Header().Get("Last-Modified"))
+
+			notModified := utils.PerformRequest(router, "GET", path, nil,
+				utils.Header{Key: "If-None-Match", Value: etag})
+			assert.Equal(t, http.StatusNotModified, notModified.Code)
+			assert.Zero(t, notModified.Body.Len())
+			assert.NotEmpty(t, notModified.Header().Get("Cache-Control"))
+			assert.Equal(t, etag, notModified.Header().Get("ETag"))
+
+			stale := utils.PerformRequest(router, "GET", path, nil,
+				utils.Header{Key: "If-None-Match", Value: `"nope"`})
+			assert.Equal(t, http.StatusOK, stale.Code)
+			assert.NotZero(t, stale.Body.Len())
+		})
+	}
+
+	_ = service.DeletePackage(context.Background(), "awesome-lib", "1.0.0") //nolint:errcheck
+}
+
 func TestPackageControllerGetUI(t *testing.T) {
 	objectStorageManager := initObjectStorage()
 	router := gin.New()

--- a/api/package-controller_test.go
+++ b/api/package-controller_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -298,6 +299,64 @@ func TestCacheControlHeader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
 			assert.Equal(t, tt.expected, cacheControlHeader(tt.version))
+		})
+	}
+}
+
+func TestETagMatches(t *testing.T) {
+	tests := []struct {
+		name        string
+		ifNoneMatch string
+		etag        string
+		expected    bool
+	}{
+		{"exact match", `"abc"`, `"abc"`, true},
+		{"weak request ETag", `W/"abc"`, `"abc"`, true},
+		{"weak response ETag", `"abc"`, `W/"abc"`, true},
+		{"match in second position", `"stale", W/"abc"`, `"abc"`, true},
+		{"wildcard", `*`, `"abc"`, true},
+		{"stale value", `"stale"`, `"abc"`, false},
+		{"empty header", ``, `"abc"`, false},
+		{"empty ETag", `*`, ``, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, etagMatches(tt.ifNoneMatch, tt.etag))
+		})
+	}
+}
+
+func TestNotModified(t *testing.T) {
+	lastModified := time.Date(2026, time.August, 21, 12, 30, 45, 0, time.UTC)
+	tests := []struct {
+		name            string
+		ifNoneMatch     string
+		ifModifiedSince string
+		lastModified    time.Time
+		etag            string
+		expected        bool
+	}{
+		{"matching If-None-Match", `"abc"`, "", lastModified, `"abc"`, true},
+		{"stale If-None-Match takes precedence", `"stale"`, lastModified.Format(http.TimeFormat), lastModified, `"abc"`, false},
+		{"If-Modified-Since exact match", "", lastModified.Format(http.TimeFormat), lastModified, `"abc"`, true},
+		{"If-Modified-Since older", "", lastModified.Add(-time.Second).Format(http.TimeFormat), lastModified, `"abc"`, false},
+		{"malformed date", "", "not-a-date", lastModified, `"abc"`, false},
+		{"zero last modified", "", lastModified.Format(http.TimeFormat), time.Time{}, `"abc"`, false},
+		{"sub-second last modified", "", lastModified.Format(http.TimeFormat), lastModified.Add(987 * time.Millisecond), `"abc"`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.ifNoneMatch != "" {
+				r.Header.Set("If-None-Match", tt.ifNoneMatch)
+			}
+			if tt.ifModifiedSince != "" {
+				r.Header.Set("If-Modified-Since", tt.ifModifiedSince)
+			}
+
+			assert.Equal(t, tt.expected, notModified(r, tt.etag, tt.lastModified))
 		})
 	}
 }

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -300,16 +300,41 @@
             "description": "File path within the package. Nested paths are supported (e.g. `dist/awesome-lib.min.js`). The leading `/` captured by the Gin wildcard is stripped internally.",
             "required": true,
             "schema": { "type": "string", "example": "dist/awesome-lib.min.js" }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "description": "ETag validator from a previous response",
+            "schema": { "type": "string", "example": "\"abc123\"" }
+          },
+          {
+            "name": "If-Modified-Since",
+            "in": "header",
+            "description": "Last-Modified validator from a previous response, used when If-None-Match is absent",
+            "schema": { "type": "string", "example": "Fri, 21 Aug 2026 12:30:45 GMT" }
           }
         ],
         "responses": {
           "200": {
             "description": "File content",
+            "headers": {
+              "ETag": {
+                "description": "Quoted S3 object ETag",
+                "schema": { "type": "string" }
+              },
+              "Last-Modified": {
+                "description": "S3 object modification time in HTTP-date format",
+                "schema": { "type": "string" }
+              }
+            },
             "content": {
               "application/javascript": {},
               "text/css": {},
               "application/octet-stream": {}
             }
+          },
+          "304": {
+            "description": "Not modified — the client's `If-None-Match` or `If-Modified-Since` still matches"
           },
           "400": {
             "description": "Invalid package identifier format"

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1826,6 +1826,17 @@ curl http://localhost:8080/gimme/my-lib@1.0/my-lib.min.js</code></pre>
                             </tbody>
                         </table>
                     </div>
+                    <p>
+                        Every file response also carries <code>ETag</code> and
+                        <code>Last-Modified</code>. Gimme answers
+                        <code>304 Not Modified</code> when
+                        <code>If-None-Match</code> matches, or when
+                        <code>If-Modified-Since</code> matches and
+                        <code>If-None-Match</code> is absent. Revalidating a
+                        partial version therefore transfers only headers when
+                        the file has not changed, instead of downloading the
+                        body again.
+                    </p>
 
                     <h3>
                         Level 2 — Internal Redis cache


### PR DESCRIPTION
Closes #48.

`GET /gimme/<package>@<version>/<file>` emitted `Cache-Control` but no validator, so any cache in front of gimme re-downloaded the entire body from S3 on every revalidation — every five minutes for a partial version, whose `max-age` is 300.

Every 200 now carries `ETag` and `Last-Modified`, both read from the `ObjectInfo` the handler already had from `Stat()`, so no extra S3 call is made. `If-None-Match` is compared weakly and answers `304` with no body; `If-Modified-Since` does the same, but only when `If-None-Match` is absent.

## Verified on two local instances, one shared Garage bucket

Same objects, same request, only the binary differs.

```text
BEFORE (main)                       AFTER (this branch)
GET  → 200, 33 bytes                GET  → 200, 33 bytes
Cache-Control: max-age=300          Cache-Control: max-age=300
(no ETag, no Last-Modified)         ETag: "0da443e3cddb8a2026a3a36199b7146c"
                                    Last-Modified: Fri, 21 Aug 2026 09:00:27 GMT

GET + If-None-Match → 200, 33 bytes GET + If-None-Match → 304, 0 bytes
```

Full matrix, run against the partial version `awesome-lib@1.0`:

| Request | Result |
|---|---|
| exact ETag | `304`, 0 bytes |
| `W/"…"` (weak) | `304`, 0 bytes |
| list, match in second position | `304`, 0 bytes |
| `*` | `304`, 0 bytes |
| stale ETag | `200`, 33 bytes |
| `If-Modified-Since` == `Last-Modified` | `304`, 0 bytes |
| `If-Modified-Since` older | `200`, 33 bytes |
| stale `If-None-Match` **and** matching `If-Modified-Since` | `200`, 33 bytes — precedence |
| malformed `If-Modified-Since` | `200`, 33 bytes |

The 304 itself:

```text
HTTP/1.1 304 Not Modified
Cache-Control: public, max-age=300
Etag: "0da443e3cddb8a2026a3a36199b7146c"
Last-Modified: Fri, 21 Aug 2026 09:00:27 GMT
```

No `Content-Type` and no `Content-Length` — `net/http` strips them on a 304, so nothing had to be done for that.

## Decisions

- **`http.ServeContent` was rejected.** `minio.Object` is an `io.ReadSeeker`, so it would have supplied the conditional logic for free — and Range/206 with it, which is its own feature: a new status code, and every `Seek` on a `minio.Object` re-issues a GET against S3. `TODO.md` schedules this task before the brotli/gzip one precisely because it is small.
- **Precedence is an early return, not a disjunction.** A present-but-stale `If-None-Match` answers 200 and the date is never consulted.
- **`LastModified` is truncated to the second before comparison.** S3 keeps sub-second precision that `Last-Modified` cannot carry; without the truncation a client echoing back our own header looks stale on every request. Pinned by a unit case.
- **`minio.ObjectInfo.ETag` arrives unquoted** and is wrapped in `"`. A multipart upload yields a `-N` suffix instead of an MD5 — an opaque validator either way.
- **The `If-None-Match` list is split on `,`** without honouring commas inside a quoted ETag. S3 ETags never contain one; the worst case is a 200 with a body, never a wrong 304.
- **The 304 answers pinned versions too.** `immutable` does not stop a cache from revalidating, and answering costs nothing.
- **No `Vary` header:** nothing varies yet. #47 must add it together with a per-encoding ETag suffix, or a cache serves a brotli body to a client that asked for identity. Noted in `TODO.md`.

## Tests

The end-to-end round trip is an integration test, and that is forced rather than chosen: `MockOSManager.GetObject` returns `&minio.Object{}`, whose `Stat()` carries neither an ETag nor a modification time, so no mock fixture can express this behaviour. The weak comparison and the precedence rule are extracted as pure functions and unit-tested directly.

## Quality gate

| Check | Result |
|---|---|
| `gofmt -l .` | no output |
| `golangci-lint run ./...` | `0 issues.`, exit 0 |
| `make test` | green, `api` at `ok … coverage: 89.7%`, no `FAIL` |
| `make build` | exit 0 |

Docs updated in this PR, as `TODO.md` requires: README *Caching Strategy*, the docs-site Caching section, and the `304` plus the conditional request headers in `docs/api/swagger.json`.
