### PR TITLE
fix: roll back a failed upload instead of leaving a partial package

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ Response: `201 Created`
 
 Uploads are limited by request size, ZIP file-entry count, and cumulative declared decompressed size. Exceeding any configured limit returns `413 Payload Too Large` with an error naming the limit that was exceeded.
 
+A failed upload is rolled back: the package either lands entirely or leaves nothing behind, so the same `name@version` can be retried immediately. If the rollback itself fails, the `500 Internal Server Error` says so and directs you to remove the partial package with `DELETE /packages/<pkg>@<version>` before retrying. A server killed outright (`kill -9`, OOM) has no chance to roll anything back and leaves a partial package that answers `409 Conflict` on retry; remove it with the same `DELETE /packages/<pkg>@<version>` request.
+
 #### Archive layout
 
 The paths inside the archive become the URLs, with one exception: when the archive wraps everything in a **single top-level folder**, that folder is stripped.

--- a/TODO.md
+++ b/TODO.md
@@ -172,6 +172,15 @@ Before touching application code, so the lint inventory is known in advance.
   *Prove it:* Go test — `NewConfig()` on the example file must be **accepted** as far as the secret goes. Red output today: `secret must be at least 32 bytes long (got 6)`.
   *Independent of #59* — opposite directions, no ordering constraint.
 
+- [x] **#114 — A failed upload leaves a partial package that cannot be retried** *(filed mid-flight, after #47)*
+  `CreatePackage` uploads entries through an `errgroup`; the first error aborts the group and the controller answers `500`, but every object already stored stays in the bucket. `ObjectExists` returns true on a single object under the prefix, so the retry is refused with `409` — the client is told the upload failed *and* told it cannot try again. Older than the compression work: an `AddObject` failure on the identity object has always done this. #47 only widened the ways to fail after some objects are already written.
+  *Files:* `internal/content/content-service.go`, `README.md`, `api/package-controller_integration_test.go`, `test/mocks/objectstorage-manager-fail-after.go`
+  *Prove it:* integration test against Garage. `MockOSManagerErr` cannot express this — it fails *every* call, so nothing is ever stored. The new `MockOSManagerFailAfter` wraps a real manager and fails the Nth `AddObject`, which is what leaves the package half-written. Red output: two objects left under `rollback-lib@1.0.0/`, and the retry answering `409` where `201` is expected.
+  *Settled while implementing:* **option 1 of the issue — roll the prefix back**, so the upload is atomic from the client's point of view. Option 2 (variant failures non-fatal) only covers the paths #47 added and degrades silently; option 3 (document the remedy) changes no behaviour — it is kept as a **complement**, since it is the only thing that helps the one case a rollback cannot reach.
+  *The rollback context is `WithTimeout(WithoutCancel(ctx), 30s)`.* The common trigger is a client that disconnected mid-upload, which cancels the request context — a rollback on that context fails and lands straight back in the bug. `WithoutCancel` keeps the values, so this is not a bare `context.Background()`; it is the one deliberate exception to the propagation rule.
+  *The prefix carries a trailing slash*, unlike `DeletePackage`: rolling back `pkg@1.0.0` without it would also delete `pkg@1.0.0-beta`. `ObjectExists` already appends the slash for that exact reason. **`DeletePackage` still omits it** — pre-existing, out of scope here, worth its own issue.
+  *What it does not cover:* `kill -9`, OOM, a node that dies — nothing runs, so nothing is rolled back. A graceful `SIGTERM` is covered as long as the rollback fits in the 60 s shutdown grace of `application.go`. Closing the `kill -9` hole needs a persistent "upload in progress" marker read at startup — another issue, not this one.
+
 ---
 
 ## Phase 4 — Features

--- a/api/package-controller_integration_test.go
+++ b/api/package-controller_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/ziggornif/gimme/internal/auth"
 	"github.com/ziggornif/gimme/internal/content"
+	"github.com/ziggornif/gimme/test/mocks"
 	"github.com/ziggornif/gimme/test/utils"
 )
 
@@ -412,4 +413,32 @@ func TestPackageControllerDelete(t *testing.T) {
 		utils.Header{Key: "Authorization", Value: fmt.Sprintf("Bearer %s", rawToken)})
 
 	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestPackageControllerCreateFailureRollsBack(t *testing.T) {
+	objectStorageManager := initObjectStorage()
+	failing := &mocks.MockOSManagerFailAfter{OSManager: objectStorageManager, FailAt: 2}
+
+	router := gin.New()
+	authManager := newTestAuthManager(t)
+	_, rawToken, _ := authManager.CreateToken(context.Background(), "test", "")
+	service := content.NewContentService(failing, nil, 0, content.UploadLimits{})
+	NewPackageController(router, authManager, service)
+
+	t.Cleanup(func() {
+		_ = objectStorageManager.RemoveObjects(context.Background(), "rollback-lib@1.0.0/") //nolint:errcheck
+	})
+
+	resp := createPackage(t, router, "rollback-lib", "1.0.0", "../test/test.zip", rawToken)
+	require.Equal(t, http.StatusInternalServerError, resp.Code)
+
+	remaining := objectStorageManager.ListObjects(context.Background(), "rollback-lib@1.0.0/")
+	assert.Empty(t, remaining, "a failed upload must leave no object behind")
+
+	healthyRouter := gin.New()
+	healthyService := content.NewContentService(objectStorageManager, nil, 0, content.UploadLimits{})
+	NewPackageController(healthyRouter, authManager, healthyService)
+
+	retry := createPackage(t, healthyRouter, "rollback-lib", "1.0.0", "../test/test.zip", rawToken)
+	assert.Equal(t, http.StatusCreated, retry.Code)
 }

--- a/internal/content/content-service.go
+++ b/internal/content/content-service.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const uploadRollbackTimeout = 30 * time.Second
+
 type ContentService struct {
 	objectStorageManager storage.ObjectStorageManager
 	cacheManager         cache.CacheManager // nil = cache disabled
@@ -227,7 +229,7 @@ func (svc *ContentService) CreatePackage(ctx context.Context, name string, versi
 	}
 
 	if err := eg.Wait(); err != nil {
-		return errors.NewBusinessError(errors.InternalError, fmt.Errorf("error while uploading package files: %w", err))
+		return svc.rollbackPartialUpload(ctx, folderName, err)
 	}
 	if entries := compressedEntries.Load(); entries > 0 {
 		logrus.Infof("[ContentService] CreatePackage - compressed %d entries into %d variants", entries, uploadedVariants.Load())
@@ -235,6 +237,19 @@ func (svc *ContentService) CreatePackage(ctx context.Context, name string, versi
 
 	metrics.PackagesUploadedTotal.Inc()
 	return nil
+}
+
+func (svc *ContentService) rollbackPartialUpload(ctx context.Context, folderName string, uploadErr error) *errors.GimmeError {
+	rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), uploadRollbackTimeout)
+	defer cancel()
+
+	// The slash confines deletion to this package version when another version shares its prefix.
+	if rollbackErr := svc.objectStorageManager.RemoveObjects(rollbackCtx, folderName+"/"); rollbackErr != nil {
+		logrus.Errorf("[ContentService] CreatePackage - Could not roll back partial upload for %s: %v", folderName, rollbackErr)
+		return errors.NewBusinessError(errors.InternalError, fmt.Errorf("error while uploading package files: %w (the partial upload could not be removed, delete it with DELETE /packages/%s before retrying)", uploadErr, folderName))
+	}
+
+	return errors.NewBusinessError(errors.InternalError, fmt.Errorf("error while uploading package files: %w", uploadErr))
 }
 
 // IsPinnedVersion returns true if version is an explicit full 3-part semver

--- a/test/mocks/objectstorage-manager-fail-after.go
+++ b/test/mocks/objectstorage-manager-fail-after.go
@@ -1,0 +1,43 @@
+package mocks
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/ziggornif/gimme/internal/errors"
+
+	"github.com/minio/minio-go/v7"
+)
+
+// OSManager mirrors storage.ObjectStorageManager instead of importing it:
+// internal/storage's own tests live in package storage and import this package,
+// so a reference to internal/storage here is an import cycle.
+type OSManager interface {
+	CreateBucket(ctx context.Context, bucketName string, location string) *errors.GimmeError
+	AddObject(ctx context.Context, objectName string, file *zip.File) *errors.GimmeError
+	AddBytes(ctx context.Context, objectName string, data []byte, contentType string) *errors.GimmeError
+	GetObject(ctx context.Context, objectName string) (*minio.Object, *errors.GimmeError)
+	ObjectExists(ctx context.Context, objectName string) bool
+	ListObjects(ctx context.Context, objectParentName string) []minio.ObjectInfo
+	RemoveObjects(ctx context.Context, objectParentName string) *errors.GimmeError
+	Ping(ctx context.Context) *errors.GimmeError
+}
+
+// MockOSManagerFailAfter delegates every call to a real storage manager and
+// fails the AddObject call numbered FailAt (1-based). MockOSManagerErr fails
+// every call, which aborts before anything is stored — the half-written
+// package this reproduces needs some entries to land first.
+type MockOSManagerFailAfter struct {
+	OSManager
+	FailAt int64
+	calls  atomic.Int64
+}
+
+func (osc *MockOSManagerFailAfter) AddObject(ctx context.Context, objectName string, file *zip.File) *errors.GimmeError {
+	if osc.calls.Add(1) == osc.FailAt {
+		return errors.NewBusinessError(errors.InternalError, fmt.Errorf("boom"))
+	}
+	return osc.OSManager.AddObject(ctx, objectName, file)
+}


### PR DESCRIPTION
A failed upload left behind the objects it had already stored, and the next `POST /packages` for the same `name@version` was refused with `409 Conflict`. The client was told the upload had failed, and told it could not try again.

`CreatePackage` uploads archive entries through an `errgroup` and returns on the first error. The `ObjectExists` guard answers true on a single object under the `<pkg>@<version>/` prefix, so one stored entry was enough to block every retry.

## Worse than the 409

Not stated in the issue, found while running this against a live instance: **the half-written package is served**. A 500 on the fifth of five entries still leaves `GET /gimme/demo-lib@1.0.0` answering `200` and serving two files, with the other three answering `404`. A client pointing at that package gets silent holes, not an outage.

## The fix

The `eg.Wait()` failure path now removes the package prefix, so the upload is atomic from the client's point of view: it lands entirely, or it leaves nothing.

- **The rollback context is `WithTimeout(WithoutCancel(ctx), 30s)`.** The common trigger is a client that disconnected mid-upload, which cancels the request context — a rollback on that context would fail and land straight back in the bug. `WithoutCancel` keeps the context values, so this is not a bare `context.Background()`; it is a deliberate, single exception to the propagation rule.
- **The prefix carries a trailing slash.** Rolling back `pkg@1.0.0` without it would also delete `pkg@1.0.0-beta`. `ObjectExists` already appends it for that exact reason. `DeletePackage` still omits it — pre-existing, out of scope here, worth its own issue.
- **A rollback that itself fails is logged and surfaced**, never swallowed: the 500 names `DELETE /packages/<pkg>@<version>` as the remedy, since that case puts the client back in the 409 situation.
- Option 2 of the issue (variant failures non-fatal) only covers the paths #47 added and degrades silently. Option 3 (document the remedy) is kept as a **complement**, because it is the only thing that helps the one case a rollback cannot reach.

## What it does not cover

`kill -9`, OOM, a node that dies: nothing runs, so nothing is rolled back. A graceful `SIGTERM` is covered as long as the rollback fits in the 60 s shutdown grace in `application.go`. Closing the `kill -9` hole needs a persistent "upload in progress" marker read at startup — another issue, not this one. Documented in the README.

## Failing test first

`MockOSManagerErr` cannot express this defect: it fails *every* call, so nothing is ever stored and the package is never half-written. The new `MockOSManagerFailAfter` wraps a real manager and fails the Nth `AddObject`.

`TestPackageControllerCreateFailureRollsBack`, run against Garage **before** the fix:

```
    package-controller_integration_test.go:436:
        	Error:      	Should be empty, but was [
        	              rollback-lib@1.0.0/awesome.min.css (46 B)
        	              rollback-lib@1.0.0/test (11 B)]
        	Messages:   	a failed upload must leave no object behind
    package-controller_integration_test.go:443:
        	Error:      	Not equal:
        	            	expected: 201
        	            	actual  : 409
--- FAIL: TestPackageControllerCreateFailureRollsBack (0.07s)
FAIL	github.com/ziggornif/gimme/api	0.743s
```

After the fix: `ok github.com/ziggornif/gimme/api`.

## Verified on two live instances

Not a mock: two real binaries against Garage, one built from `main`, one from this branch, each on its own bucket. The S3 failure is real — a Garage `--max-objects 2` bucket quota, so the PUTs genuinely fail server-side partway through a five-entry archive.

Upload #1, both answer `500`. What each leaves behind:

| | objects left in the bucket | `GET /gimme/demo-lib@1.0.0` |
|---|---|---|
| `main` | **2** | **200** — serves a broken package |
| this branch | **0** | 404 |

Quota lifted (the S3 incident is over), retry of the same `name@version`:

```
main          409  {"error":"the package demo-lib@1.0.0 already exists"}
this branch   201
```

Files served afterwards:

```
main          a.js 404   b.js 200   c.js 200   d.js 404   e.js 404
this branch   a.js 200   b.js 200   c.js 200   d.js 200   e.js 200
```

The repaired package is complete, compression variants included:

```
identity            -> 200  Content-Length: 2772   Vary: Accept-Encoding
Accept-Encoding: br -> 200  Content-Encoding: br   Content-Length: 68
```

## Quality gate

```
gofmt -l .                # empty
golangci-lint run ./...   # 0 issues.
make test                 # all packages ok, api 91.0% coverage
make build                # ok
```

The lint run caught a real defect in the first version of the new mock: it embedded `storage.ObjectStorageManager`, which made `test/mocks` import `internal/storage`, while `internal/storage/objectstorage-manager_test.go` is `package storage` and imports `test/mocks` — an import cycle. The mock now mirrors the interface's method set locally instead.

Closes #114.
