### PR TITLE
fix(build): give Garage a virgin state on every start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ GARAGE_CONTAINER ?= gimme-garage-test
 garage-start:
 	@echo "Starting Garage $(GARAGE_VERSION)..."
 	@docker rm -f $(GARAGE_CONTAINER) >/dev/null 2>&1 || true
-	@mkdir -p /tmp/garage/{meta,data}
 	@printf '%s\n' \
 		'metadata_dir = "/var/lib/garage/meta"' \
 		'data_dir     = "/var/lib/garage/data"' \
@@ -82,8 +81,8 @@ garage-start:
 	@docker run -d --name $(GARAGE_CONTAINER) \
 		-p 3900:3900 -p 3901:3901 -p 3903:3903 \
 		-v /tmp/garage.toml:/etc/garage.toml \
-		-v /tmp/garage/meta:/var/lib/garage/meta \
-		-v /tmp/garage/data:/var/lib/garage/data \
+		--tmpfs /var/lib/garage/meta \
+		--tmpfs /var/lib/garage/data \
 		dxflrs/garage:$(GARAGE_VERSION)
 	@echo "Waiting for Garage to be ready..."
 	@for i in $$(seq 1 15); do \
@@ -102,13 +101,22 @@ garage-start:
 		docker exec $(GARAGE_CONTAINER) /garage key create gimme-key && \
 		docker exec $(GARAGE_CONTAINER) /garage bucket create gimme && \
 		docker exec $(GARAGE_CONTAINER) /garage bucket allow --read --write --owner gimme --key gimme-key
+	@echo "Waiting for the S3 API on :3900..."
+	@for i in $$(seq 1 15); do \
+		curl -s -o /dev/null -m 2 http://localhost:3900 && exit 0; \
+		echo "  attempt $$i/15..."; \
+		sleep 2; \
+	done; \
+	echo "ERROR: the S3 API on :3900 never answered"; \
+	docker logs $(GARAGE_CONTAINER); \
+	exit 1
 	@echo "Garage ready."
 
 .PHONY: garage-stop
 garage-stop:
 	@echo "Stopping Garage..."
 	@docker rm -f $(GARAGE_CONTAINER) >/dev/null 2>&1 || true
-	@docker run --rm -v /tmp:/tmp alpine sh -c "rm -rf /tmp/garage /tmp/garage.toml" 2>/dev/null || true
+	@rm -f /tmp/garage.toml 2>/dev/null || true
 	@echo "Done."
 
 .PHONY: test-integration

--- a/TODO.md
+++ b/TODO.md
@@ -115,6 +115,15 @@ Before touching application code, so the lint inventory is known in advance.
   *Files:* `Dockerfile`, `Makefile`
   *Prove it:* shell output — binary size inside the image, `docker save | gzip | wc -c`, and startup timing.
 
+- [x] **#115 — `make test` is not reproducible: `garage-start` assumes virgin metadata** *(filed mid-flight, during #47)*
+  `garage-start` bind-mounted `/tmp/garage/{meta,data}` and then hardcoded `garage layout apply --version 1`, which is only correct against a virgin metadata directory. When the directory survives a previous run the layout is already at version 1, `layout assign` stages version 2, and the hardcoded apply is refused: `Error: Internal error: Invalid new layout version`. Same cause, second symptom: the objects of one run survived into the next, so an interrupted suite left packages in the bucket and the next upload of the same `name@version` was answered `409` by the duplicate-package check.
+  *Files:* `Makefile` — **build tooling only, no Go code**
+  *Prove it:* shell output. **The issue's own repro was stale** — `ca12632` had since added a `/tmp/garage` cleanup to `garage-stop`, so two *complete* `make test` runs pass on `main` and prove nothing. Corrected in a comment on the issue: the state only survives when `garage-stop` is not reached, so the red step must leave it behind first — `make garage-start` twice in a row, or `make garage-start` followed by `make test`.
+  *Fix:* `--tmpfs` for `meta` and `data` instead of bind mounts, so every start gets virgin metadata and `--version 1` is correct **by construction** rather than by luck. `garage.toml` stays a bind mount — the recipe regenerates it on each start.
+  *Rejected:* reading the next layout version from `garage layout show`. Fixes the layout error only, leaves the object pollution, and adds shell parsing for it.
+  *Two follow-ons in the same change:* `garage-stop`'s `alpine` round-trip existed only to delete root-owned files Docker had written into the bind mount — with tmpfs there are none, so a plain `rm -f /tmp/garage.toml` replaces it. And a second readiness wait on `:3900` was added after the bucket is created: the existing loop waits on `garage status` (RPC, `:3901`), which is necessary since `NODE_ID` is read from it, but nothing waited on the port the suite actually calls. It also catches a stale Docker Desktop port forwarding, which has cost a debugging session before.
+  *One-off on existing checkouts:* a `/tmp/garage` left by the old Makefile is root-owned and is never touched again. Remove it once with `docker run --rm -v /tmp:/tmp alpine rm -rf /tmp/garage`. Deliberately not automated — migration code in a Makefile outlives its purpose.
+
 > **#53 — Multi-arch Docker image: closed, not scheduled.** No one has asked for an arm64 image, and the `linux/arm64` binary already covers the rare case. The published image is `linux/amd64` only — verified: the registry serves a plain `manifest.v2`, not a manifest list. Reopen if someone actually deploys on ARM; the `Dockerfile` already honours `TARGETOS`/`TARGETARCH`, so it is two `docker build` steps away.
 
 ---


### PR DESCRIPTION
`make garage-start` bind-mounted `/tmp/garage/{meta,data}` from the host and then hardcoded `garage layout apply --version 1`. That is only correct against a **virgin** metadata directory: when it survives a previous run, the layout is already at version 1, `layout assign` stages version 2, and the hardcoded apply is refused.

```
Role changes are staged but not yet committed.
Error: Internal error: Invalid new layout version
make: *** [garage-start] Error 1
```

Same cause, second symptom: the objects of one run survived into the next, so an interrupted suite left packages in the bucket and the next upload of the same `name@version` was answered `409` by the duplicate-package check.

## The issue's repro was stale — corrected before implementing

The description said `garage-stop` "removes the container and nothing else". Not true any more: `ca12632` had since added a `/tmp/garage` cleanup to it, so two *complete* `make test` runs pass on `main` and prove nothing.

The defect stands with a narrower trigger: the state survives whenever `garage-stop` is **not reached** — a suite interrupted with Ctrl-C, a run that aborts, or a `make garage-start` issued by hand to run one targeted `go test`. All three are ordinary during development, and the last one produced the output above. Full correction posted on #115.

## The fix

`meta` and `data` become `--tmpfs`, so every start gets virgin metadata and `--version 1` is correct **by construction** rather than by luck. No state leaks between runs. `garage.toml` stays a bind mount — the recipe regenerates it on each start. Test data is a few megabytes, so memory is not a concern.

Rejected: reading the next layout version from `garage layout show`. It fixes the layout error only, leaves the object pollution in place, and adds shell parsing for it.

Two follow-ons in the same target:

- `garage-stop`'s `alpine` round-trip existed only to delete root-owned files Docker had written into the bind mount. With tmpfs there are none, so a plain `rm -f /tmp/garage.toml` replaces it.
- A second readiness loop waits on `:3900` after the bucket is created. The existing loop waits on `garage status` (RPC, `:3901`), which is necessary since `NODE_ID` is read from it — but nothing waited on the port the suite actually calls. It also catches a stale Docker Desktop port forwarding, which has cost a debugging session before. CI runs on `ubuntu-latest`, which ships `curl`.

## Proof — shell output, this is build tooling

Red, on `main`, `make garage-start` twice in a row:

```
$ make garage-start   # run 1 -> exit 0
$ make garage-start   # run 2, /tmp/garage untouched

Waiting for Garage to be ready...
Role changes are staged but not yet committed.
Error: Internal error: Invalid new layout version
make: *** [garage-start] Error 1
```

Green, on this branch:

- `make garage-start` twice in a row — both exit 0, including with a stale `/tmp/garage` still present on the host;
- `make garage-start` followed by `make test` (the scenario that was red) — passes;
- two consecutive `make test` — both pass;
- `garage layout show` after the second start — `Current cluster layout version: 1`, nothing staged;
- `ls /tmp/garage` and `ls /tmp/garage.toml` after a full run — both gone.

Gate: `gofmt -l .` empty, `golangci-lint run ./...` → `0 issues.`, `make build` ok, `make test` green.

## One manual step on existing checkouts

A `/tmp/garage` left by the old Makefile is root-owned and is never touched again:

```bash
docker run --rm -v /tmp:/tmp alpine rm -rf /tmp/garage
```

Deliberately not automated — migration code in a Makefile outlives its purpose.

## Note on `TODO.md`

This branch and #116 both add an entry to `TODO.md`, in different phases and far apart in the file. Whichever merges second may need a refresh against `main`, which branch protection requires anyway.

Closes #115.
