### PR TITLE
perf: paginate the package listing and resolve partial versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ nginx limits request bodies to 1 MB by default. When gimme runs behind nginx, se
 | `DELETE` | `/tokens/:id`                | Admin auth    | Revoke an access token               |
 | `POST`   | `/packages`                  | Bearer JWT    | Upload a ZIP package                 |
 | `DELETE` | `/packages/:package`         | Bearer JWT    | Delete a package (`name@version`)    |
-| `GET`    | `/gimme/:package`            | None          | List files in a package (HTML)       |
+| `GET`    | `/gimme/:package`            | None          | Paginated package files (HTML or JSON) |
 | `GET`    | `/gimme/:package/*file`      | None          | Serve a specific file from a package |
 | `GET`    | `/metrics`                   | None          | OpenMetrics/Prometheus endpoint      |
 | `GET`    | `/docs`                      | None          | Static API documentation (ReDoc)     |

--- a/TODO.md
+++ b/TODO.md
@@ -327,22 +327,47 @@ Before touching application code, so the lint inventory is known in advance.
   ⚠️ *Serving cannot be unit-tested against the mocks* — `MockOSManager.GetObject` returns `&minio.Object{}` and `Stat()` on that zero value panics. Same wall as #48 and #47: the digest is proven end-to-end in `api/package-controller_integration_test.go` against Garage, and only the hashing helper is unit-tested.
   *Deliberately out of scope:* SHA-256/SHA-512 variants, a per-package manifest object, `GET /packages` JSON (that is #49's, and it should read the same metadata), and backfilling hashes for already-uploaded packages.
 
-- [ ] **#84 — Paginate the package listing (UI + API)** ⚠️ *settle before or with #49*
+- [x] **#84 — Paginate the package listing (UI + API)** ⚠️ *settle before or with #49*
   `GET /gimme/<pkg>@<version>` returns every object under the prefix in one response. Measured on `@mui/icons-material@5.15.21` (31 843 files): **39.7 MB of HTML** for an 18.7 MB package, 1.3 s server-side, and a browser that visibly struggles. A design-system icon package is the primary use case for a CDN, not an exotic input.
   *Files:* `templates/package.tmpl`, `api/package-controller.go`, `internal/content/content-service.go`, `internal/storage/objectstorage-manager.go`
   *Start at the storage layer:* `ObjectStorageManager.ListObjects` hardcodes `Recursive: true` and drains the channel into a full slice, which makes pagination impossible for every caller above it. S3 `ListObjectsV2` is natively paginated (`MaxKeys` + continuation token); minio-go already exposes it.
   *Order:* #49 has no listing contract yet — agreeing this one first means #49 adopts it instead of inventing a second.
   *Also:* `GetFiles` uses the raw prefix with no version resolution, so `pkg@5` lists every version's files mixed together with no indication of which version each belongs to.
+  *Settled while implementing — the pagination contract, which #49 adopts:* keyset only, `?limit=N` (default 50, clamped to [1, 500]) and `?after=<last raw object key>`. Offset and numbered page links were considered and rejected: S3 has no offset, so `?page=100` would re-drain 10 000 keys — it reintroduces the defect on the later pages. `Link` carries `rel="first"` and `rel="next"`; `rel="prev"` and `rel="last"` are **not** derivable from a keyset cursor and are deliberately absent, so the browser's Back button is the Previous. GitLab's keyset mode makes the same two omissions.
+  *The cursor is `StartAfter`, not a continuation token.* Verified in minio-go v7.3.0: `ListObjects` and `ListObjectsIter` are the only public listing methods and neither exposes `NextContinuationToken`, even though `ListBucketV2Result` parses it. `StartAfter` is the whole of the available cursor.
+  ⚠️ *There is no total, and no amount of API archaeology produces one.* `ListBucketV2Result` in v7.3.0 has no `KeyCount` field at all; S3's own `KeyCount` counts the page, not the prefix. Object counts live in the MinIO admin API (`madmin`, not a dependency) and Garage's admin API — both bucket-level, both needing admin credentials. S3 Inventory is an async manifest job Garage does not implement. So `total` is reported exactly in the one case where it is free — the whole listing fitted in a single page — and is `null` otherwise. Do not add a counting pass in #49.
+  *JSON rides the existing route* under `Accept: application/json`, negotiated with `c.NegotiateFormat(gin.MIMEHTML, gin.MIMEJSON)` so a browser's `Accept` and a bare `*/*` both still get HTML. A dedicated `GET /packages/:package/files` was rejected — it would be a third listing route for #49 to reconcile.
+  *Version resolution landed here, and it is what #85 reuses.* `ListCommonPrefixes` does a non-recursive list on `pkg@`: minio sets delimiter `/` and yields each common prefix as `ObjectInfo{Key: prefix}`, so ~10 entries come back instead of 31 843. ⚠️ *Cheap in scaling, not cheap per call.* Measured against Garage v1.3.1 with the real `@mui/icons-material@5.15.21` loaded, read from the service's own `gimme_s3_operation_duration_seconds` histogram: `ListCommonPrefixes` costs 12.9 ms alone but **234 ms at concurrency 20**, against 44.5 ms for `ListObjectsPage` — roughly 2.5x a paged list, and that one extra call per request is what makes a partial-version listing 48 req/s where a pinned one does 213. The cost is **constant in package size** — the same call on a 6-object package measured 239 ms, indistinguishable — so the primitive does what it was chosen for, but budget it as a real round trip rather than a free lookup. The listing prefix is now `pkg@<resolved>/` **with the trailing slash** — its absence is what let `mui@5` reach `mui@50.1.0`, and it also let `mui@1.0.0` reach `mui@1.0.0-beta`. The partial-match predicate settled in #45 + #46 was extracted from `filterArray` into `versionMatches` and is shared, so the two resolution paths cannot drift.
+  ⚠️ *Two defects that only exist once there are pages, both caught in review with a failing test each:* a `.br`/`.gz` variant is hidden by looking up its identity sibling in the set of listed keys, so a page opening on `app.js.gz` whose sibling `app.js` fell on the previous page showed the variant as a file — the cursor's own identity sibling has to be seeded into that set. And `HasMore` computed from raw keys advertised a `Next` link to a page holding nothing but filtered-out variants, i.e. a 404 on a link just rendered — so the page is only advertised once a *visible* file is known to be on it, by collecting `limit + 1` and resuming from the raw key preceding the extra one.
+  *Filtering shrinks a page,* so the loop keeps fetching raw pages until it holds `limit` visible files: with brotli and gzip variants for every entry, one raw page of 100 keys renders ~33 rows. Cost stays proportional to the page, not to the package.
+  *`getLatestPackagePath` was left untouched* — same file, same 31 843-object drain, but it is #85's subject and folding it in here would have made one diff out of two reviewable ones.
 
 - [ ] **#85 — Partial-version requests pay a full recursive listing** *(after #45 + #46)*
   `getLatestPackagePath` calls `ListObjects` on every partial-version file request, so serving one 489 B file drains all 31 843 objects. Measured: **0.023 s pinned vs 0.810 s partial — 35x**, cache disabled. Cost scales with the file count of the package, not the size of the file served. This is the asset-serving hot path, not the browse UI.
   *Files:* `internal/content/content-service.go`, `internal/storage/objectstorage-manager.go`
   *Approach:* resolve from the version list, not the object list — a delimited (non-recursive) list on the `pkg@` prefix returns one common prefix per version instead of one entry per file, then build the path directly as the pinned branch already does.
+  *The primitive already exists:* #84 added `ObjectStorageManager.ListCommonPrefixes` and the shared `versionMatches` predicate for exactly this. Reuse them — do not write a second resolution.
   *Order:* same function as #45 + #46, which rewrite the resolution. Land after them or fold in — doing it first means writing the resolution tests twice.
+  *Measured under load while validating #84,* same file, same package, only the version form differing — Garage v1.3.1, concurrency 5:
+
+  | Package | pinned | partial |
+  |---|---|---|
+  | 6 objects | 80.8 req/s | 52.6 req/s (1.5x slower) |
+  | 31 843 objects | 1540 req/s, p50 2 ms | **1.4 req/s, p50 3.46 s** |
+
+  A thousandfold on the asset-serving hot path, and it tracks the object count exactly as the drain predicts.
   *Note:* the cache mitigates repeat hits but is optional and does nothing for the cold path, so it does not close this.
+  ⚠️ *Budget the replacement honestly:* `ListCommonPrefixes` is constant in package size but still a ~234 ms round trip at concurrency 20 on this rig (see #84). It replaces an O(objects) drain with an O(1) call — a large win here — but it is not free, so the cache stays worth having rather than being made redundant by it.
 
 - [ ] **#49 — Browse: `GET /packages` and version listing**
   Independent of everything else. Good candidate if a visible win is wanted early. See #84 — the pagination contract should be settled first, or in the same pass.
+
+- [ ] **#122 — Browse a package by folder, not one flat list** *(filed mid-flight during #84; after #84)*
+  The listing renders one row per object labelled with the full object key, and there is no way to descend. #84 bounded the response (105 130 B for 50 rows on `@mui/icons-material@5.15.21`) but a bound is not a shape — the two directories that package actually has stay invisible while `mui-icons@5.15.21/` is repeated on all fifty lines.
+  *Files:* `templates/package.tmpl`, `api/package-controller.go`, `internal/content/content-service.go`
+  ⚠️ *A folder view alone does not fix it, and assuming otherwise is the trap here.* That package holds 21 229 files directly at its root, so a delimited listing of the root still returns 21 231 entries — counted from jsDelivr's data API, whose own folder view for this package is exactly as long. Folder view for shape, #84's keyset pagination for bound, applied **within** a level. Not alternatives.
+  *No storage work:* #84 added `ListCommonPrefixes`, a delimited list returning one common prefix per immediate child. A folder browse is that same call on a deeper prefix. The work is routing, rendering and the listing contract.
+  *Order:* settle with #49 — same browse surface, same contract, and agreeing it twice is how two of them get invented.
 
 - [ ] **#51 — `@latest`**
   Depends on #45: it shares the resolution path.

--- a/api/package-controller.go
+++ b/api/package-controller.go
@@ -7,6 +7,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -29,6 +30,25 @@ type PackageController struct {
 type packageSlice struct {
 	Name    string
 	Version string
+}
+
+const (
+	defaultListingLimit = 50
+	maxListingLimit     = 500
+)
+
+type paginationResponse struct {
+	Limit   int    `json:"limit"`
+	Next    string `json:"next"`
+	HasMore bool   `json:"has_more"`
+	Total   *int   `json:"total"`
+}
+
+type packageListingResponse struct {
+	Package    string             `json:"package"`
+	Version    string             `json:"version"`
+	Files      []content.File     `json:"files"`
+	Pagination paginationResponse `json:"pagination"`
 }
 
 func (ctrl *PackageController) getSlice(pkg string) (*packageSlice, *errors.GimmeError) {
@@ -56,8 +76,10 @@ func (ctrl *PackageController) getSlice(pkg string) (*packageSlice, *errors.Gimm
 }
 
 func (ctrl *PackageController) getHTMLPackage(c *gin.Context, pkg string, name string, version string) {
-	files, _ := ctrl.contentService.GetFiles(c.Request.Context(), name, version)
-	if len(files) == 0 {
+	limit := listingLimit(c.Query("limit"))
+	after := c.Query("after")
+	listing, _ := ctrl.contentService.GetFiles(c.Request.Context(), name, version, after, limit)
+	if len(listing.Files) == 0 {
 		c.Status(http.StatusNotFound)
 		return
 	}
@@ -68,10 +90,67 @@ func (ctrl *PackageController) getHTMLPackage(c *gin.Context, pkg string, name s
 		return
 	}
 
+	firstURL := listingURL(pkg, limit, "")
+	nextURL := ""
+	if listing.HasMore {
+		nextURL = listingURL(pkg, limit, listing.Next)
+	}
+	if c.NegotiateFormat(gin.MIMEHTML, gin.MIMEJSON) == gin.MIMEJSON {
+		links := []string{fmt.Sprintf("<%s>; rel=\"first\"", firstURL)}
+		if nextURL != "" {
+			links = append(links, fmt.Sprintf("<%s>; rel=\"next\"", nextURL))
+		}
+		c.Header("Link", strings.Join(links, ", "))
+		var total *int
+		if listing.TotalKnown {
+			total = &listing.Total
+		}
+		c.JSON(http.StatusOK, packageListingResponse{
+			Package: name,
+			Version: listing.Version,
+			Files:   listing.Files,
+			Pagination: paginationResponse{
+				Limit: limit, Next: listing.Next, HasMore: listing.HasMore, Total: total,
+			},
+		})
+		return
+	}
+
 	c.HTML(http.StatusOK, "package.tmpl", gin.H{
-		"packageName": pkg,
-		"files":       files,
+		"packageName":     pkg,
+		"resolvedVersion": listing.Version,
+		"files":           listing.Files,
+		"fileCount":       len(listing.Files),
+		"total":           listing.Total,
+		"totalKnown":      listing.TotalKnown,
+		"hasMore":         listing.HasMore,
+		"nextURL":         nextURL,
 	})
+}
+
+func listingLimit(raw string) int {
+	if raw == "" {
+		return defaultListingLimit
+	}
+	limit, err := strconv.Atoi(raw)
+	if err != nil {
+		return defaultListingLimit
+	}
+	if limit < 1 {
+		return 1
+	}
+	if limit > maxListingLimit {
+		return maxListingLimit
+	}
+	return limit
+}
+
+func listingURL(pkg string, limit int, after string) string {
+	listingPath := "/gimme/" + url.PathEscape(pkg) + "?limit=" + strconv.Itoa(limit)
+	if after != "" {
+		listingPath += "&after=" + url.QueryEscape(after)
+	}
+	return listingPath
 }
 
 func (ctrl *PackageController) createPackage(c *gin.Context) {

--- a/api/package-controller_test.go
+++ b/api/package-controller_test.go
@@ -113,6 +113,59 @@ func TestPackageControllerNotFoundURL(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+func TestListingLimitClamping(t *testing.T) {
+	tests := []struct {
+		raw      string
+		expected int
+	}{
+		{"", 50}, {"invalid", 50}, {"0", 1}, {"-10", 1}, {"501", 500}, {"250", 250},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, listingLimit(tt.raw), tt.raw)
+	}
+}
+
+func TestListingURL(t *testing.T) {
+	assert.Equal(t, "/gimme/mui@5?limit=100", listingURL("mui@5", 100, ""))
+	assert.Equal(t, "/gimme/mui@5?limit=100&after=mui%405.15.21%2Fesm%2FAbc.js", listingURL("mui@5", 100, "mui@5.15.21/esm/Abc.js"))
+}
+
+func TestPackageControllerListingContentNegotiation(t *testing.T) {
+	tests := []struct {
+		name        string
+		accept      string
+		contentType string
+		json        bool
+	}{
+		{"json", gin.MIMEJSON, gin.MIMEJSON, true},
+		{"browser", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", gin.MIMEHTML, false},
+		{"wildcard", "*/*", gin.MIMEHTML, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.SetFuncMap(TemplateFuncs())
+			router.LoadHTMLGlob("../templates/*.tmpl")
+			authManager := auth.NewAuthManager(newPackageTestStore(t))
+			service := content.NewContentService(&mocks.MockOSManager{}, nil, 0, content.UploadLimits{})
+			NewPackageController(router, authManager, service)
+
+			response := utils.PerformRequest(router, http.MethodGet, "/gimme/test@1.1.1?limit=999", nil,
+				utils.Header{Key: "Accept", Value: tt.accept})
+			assert.Equal(t, http.StatusOK, response.Code)
+			assert.Contains(t, response.Header().Get("Content-Type"), tt.contentType)
+			if tt.json {
+				assert.Contains(t, response.Header().Get("Link"), `rel="first"`)
+				assert.JSONEq(t, `{
+					"package":"test","version":"1.1.1",
+					"files":[{"name":"test@1.1.1/test.js","size":0}],
+					"pagination":{"limit":500,"next":"","has_more":false,"total":1}
+				}`, response.Body.String())
+			}
+		})
+	}
+}
+
 // countingReader counts the bytes actually consumed from a request body.
 type countingReader struct {
 	reader io.Reader

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -255,7 +255,7 @@
       "get": {
         "tags": ["package"],
         "summary": "Browse package contents",
-        "description": "Returns an HTML page listing all files available in the given package version. Supports partial semver: `awesome-lib@1.0` resolves to the latest `1.0.x`.",
+        "description": "Returns a keyset-paginated HTML or JSON listing of files available in the given package version. Supports partial semver: `awesome-lib@1.0` resolves to the latest `1.0.x`.",
         "operationId": "getPackage",
         "parameters": [
           {
@@ -264,12 +264,35 @@
             "description": "Package identifier in the form `name@version` (e.g. `awesome-lib@1.0.0` or `awesome-lib@1.0`)",
             "required": true,
             "schema": { "type": "string", "example": "awesome-lib@1.0.0" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of visible files to return (default 50, clamped to 1–500)",
+            "schema": { "type": "integer", "default": 50, "minimum": 1, "maximum": 500 }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Opaque keyset cursor returned as pagination.next by the previous page",
+            "schema": { "type": "string" }
           }
         ],
         "responses": {
           "200": {
-            "description": "HTML listing of package files",
-            "content": { "text/html": {} }
+            "description": "Paginated listing of package files",
+            "headers": {
+              "Link": {
+                "description": "RFC 8288 first and, when available, next page links for JSON responses",
+                "schema": { "type": "string" }
+              }
+            },
+            "content": {
+              "text/html": {},
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PackageListing" }
+              }
+            }
           },
           "400": {
             "description": "Invalid package identifier format"
@@ -532,6 +555,35 @@
             "type": "string",
             "format": "binary",
             "description": "ZIP archive containing the package files"
+          }
+        }
+      },
+      "PackageListing": {
+        "type": "object",
+        "required": ["package", "version", "files", "pagination"],
+        "properties": {
+          "package": { "type": "string", "example": "mui" },
+          "version": { "type": "string", "example": "5.15.21" },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "size"],
+              "properties": {
+                "name": { "type": "string", "example": "mui@5.15.21/esm/Abc.js" },
+                "size": { "type": "integer", "format": "int64", "example": 489 }
+              }
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "required": ["limit", "next", "has_more", "total"],
+            "properties": {
+              "limit": { "type": "integer", "example": 100 },
+              "next": { "type": "string", "example": "mui@5.15.21/esm/Abc.js" },
+              "has_more": { "type": "boolean", "example": true },
+              "total": { "type": "integer", "nullable": true, "description": "Exact only when the complete listing fits on the first page" }
+            }
           }
         }
       },

--- a/internal/content/content-service.go
+++ b/internal/content/content-service.go
@@ -45,9 +45,18 @@ type UploadLimits struct {
 }
 
 type File struct {
-	Name   string
-	Size   int64
-	Folder bool
+	Name   string `json:"name"`
+	Size   int64  `json:"size"`
+	Folder bool   `json:"folder,omitempty"`
+}
+
+type FileListing struct {
+	Version    string
+	Files      []File
+	Next       string
+	HasMore    bool
+	Total      int
+	TotalKnown bool
 }
 
 // NewContentService create a new content service instance.
@@ -75,7 +84,6 @@ func (svc *ContentService) UploadLimits() UploadLimits {
 func (svc *ContentService) filterArray(arr []minio.ObjectInfo, pkg string, fileName string, version string) []minio.ObjectInfo {
 	var filtered []minio.ObjectInfo
 	packagePrefix := fmt.Sprintf("%s@", pkg)
-	partialVersion := len(strings.Split(version, ".")) < 3
 
 	for _, item := range arr {
 		keyWithoutPackage, found := strings.CutPrefix(item.Key, packagePrefix)
@@ -93,20 +101,32 @@ func (svc *ContentService) filterArray(arr []minio.ObjectInfo, pkg string, fileN
 			continue
 		}
 
-		matchesVersion := candidateVersion == version
-		if partialVersion && semver.Prerelease(candidateSemver) == "" {
-			switch len(strings.Split(version, ".")) {
-			case 1:
-				matchesVersion = semver.Major(candidateSemver) == "v"+version
-			case 2:
-				matchesVersion = semver.MajorMinor(candidateSemver) == "v"+version
-			}
-		}
-		if matchesVersion {
+		if versionMatches(candidateVersion, version) {
 			filtered = append(filtered, item)
 		}
 	}
 	return filtered
+}
+
+func versionMatches(candidateVersion string, requestedVersion string) bool {
+	candidateSemver := "v" + candidateVersion
+	if !semver.IsValid(candidateSemver) {
+		return false
+	}
+	if candidateVersion == requestedVersion {
+		return true
+	}
+	if len(strings.Split(requestedVersion, ".")) >= 3 || semver.Prerelease(candidateSemver) != "" {
+		return false
+	}
+	switch len(strings.Split(requestedVersion, ".")) {
+	case 1:
+		return semver.Major(candidateSemver) == "v"+requestedVersion
+	case 2:
+		return semver.MajorMinor(candidateSemver) == "v"+requestedVersion
+	default:
+		return false
+	}
 }
 
 // getVersion get package version from an S3 object key.
@@ -356,25 +376,98 @@ func (svc *ContentService) getEncodedObject(ctx context.Context, objectPath, fil
 }
 
 // GetFiles get package files
-func (svc *ContentService) GetFiles(ctx context.Context, pkg string, version string) ([]File, *errors.GimmeError) {
-	objs := svc.objectStorageManager.ListObjects(ctx, fmt.Sprintf("%s@%s", pkg, version))
-	keys := make(map[string]struct{}, len(objs))
-	for _, obj := range objs {
-		keys[obj.Key] = struct{}{}
+func (svc *ContentService) GetFiles(ctx context.Context, pkg string, version string, after string, limit int) (FileListing, *errors.GimmeError) {
+	listing := FileListing{Version: version}
+	if !IsPinnedVersion(version) {
+		packagePrefix := pkg + "@"
+		var versions []string
+		for _, commonPrefix := range svc.objectStorageManager.ListCommonPrefixes(ctx, packagePrefix) {
+			candidate := strings.TrimSuffix(strings.TrimPrefix(commonPrefix, packagePrefix), "/")
+			if versionMatches(candidate, version) {
+				versions = append(versions, "v"+candidate)
+			}
+		}
+		if len(versions) == 0 {
+			return listing, nil
+		}
+		semver.Sort(versions)
+		listing.Version = strings.TrimPrefix(versions[len(versions)-1], "v")
 	}
 
-	var files []File
-	for _, obj := range objs {
-		if isEncodedVariant(obj.Key, keys) {
-			continue
-		}
-		files = append(files, File{
-			Name:   obj.Key,
-			Size:   obj.Size,
-			Folder: false,
-		})
+	prefix := fmt.Sprintf("%s@%s/", pkg, listing.Version)
+	cursor := after
+	keys := map[string]struct{}{}
+	seedBoundaryKeys(keys, after)
+
+	// One extra file beyond the page decides HasMore: a page is only advertised
+	// once a visible file is known to be on it, and its cursor resumes just
+	// before that file.
+	type pagedFile struct {
+		file   File
+		cursor string
 	}
-	return files, nil
+	var collected []pagedFile
+	singlePage := false
+	firstFetch := true
+
+	for len(collected) <= limit {
+		objects, hasMore := svc.objectStorageManager.ListObjectsPage(ctx, prefix, cursor, limit)
+		if firstFetch && after == "" && !hasMore {
+			singlePage = true
+		}
+		firstFetch = false
+		if len(objects) == 0 {
+			break
+		}
+		for _, object := range objects {
+			keys[object.Key] = struct{}{}
+		}
+		for _, object := range objects {
+			previous := cursor
+			cursor = object.Key
+			if isEncodedVariant(object.Key, keys) {
+				continue
+			}
+			collected = append(collected, pagedFile{
+				file:   File{Name: object.Key, Size: object.Size, Folder: false},
+				cursor: previous,
+			})
+			if len(collected) > limit {
+				break
+			}
+		}
+		if !hasMore {
+			break
+		}
+	}
+
+	if len(collected) > limit {
+		listing.HasMore = true
+		listing.Next = collected[limit].cursor
+		collected = collected[:limit]
+	}
+	listing.Files = make([]File, 0, len(collected))
+	for _, entry := range collected {
+		listing.Files = append(listing.Files, entry.file)
+	}
+	listing.Total = len(listing.Files)
+	listing.TotalKnown = singlePage && !listing.HasMore
+	return listing, nil
+}
+
+// seedBoundaryKeys primes the key set with the cursor and the identity object it
+// may encode, so a variant opening a page is still recognised when its sibling
+// was the last key of the previous one.
+func seedBoundaryKeys(keys map[string]struct{}, after string) {
+	if after == "" {
+		return
+	}
+	keys[after] = struct{}{}
+	for _, encoding := range []Encoding{EncodingBrotli, EncodingGzip} {
+		if sibling, found := strings.CutSuffix(after, encoding.suffix()); found {
+			keys[sibling] = struct{}{}
+		}
+	}
 }
 
 // isEncodedVariant reports whether a key is the encoded variant of another listed

--- a/internal/content/content-service_test.go
+++ b/internal/content/content-service_test.go
@@ -137,8 +137,8 @@ func TestContentService_GetFile_FileNameIsNotASubstringMatch(t *testing.T) {
 
 func TestContentService_GetFiles(t *testing.T) {
 	service := NewContentService(&mocks.MockOSManager{}, nil, 0, UploadLimits{})
-	files, err := service.GetFiles(context.Background(), "test", "1.1.1")
-	assert.Equal(t, 2, len(files))
+	listing, err := service.GetFiles(context.Background(), "test", "1.1.1", "", 100)
+	assert.Equal(t, 1, len(listing.Files))
 	assert.Nil(t, err)
 }
 
@@ -565,16 +565,48 @@ func (manager *listingOSManager) ListObjects(context.Context, string) []minio.Ob
 	return manager.objects
 }
 
+func (manager *listingOSManager) ListObjectsPage(_ context.Context, prefix string, after string, limit int) ([]minio.ObjectInfo, bool) {
+	var page []minio.ObjectInfo
+	for _, object := range manager.objects {
+		if !strings.HasPrefix(object.Key, prefix) || object.Key <= after {
+			continue
+		}
+		if len(page) == limit {
+			return page, true
+		}
+		page = append(page, object)
+	}
+	return page, false
+}
+
+func (manager *listingOSManager) ListCommonPrefixes(_ context.Context, prefix string) []string {
+	seen := map[string]struct{}{}
+	var prefixes []string
+	for _, object := range manager.objects {
+		rest := strings.TrimPrefix(object.Key, prefix)
+		version, _, found := strings.Cut(rest, "/")
+		if !strings.HasPrefix(object.Key, prefix) || !found {
+			continue
+		}
+		commonPrefix := prefix + version + "/"
+		if _, exists := seen[commonPrefix]; !exists {
+			seen[commonPrefix] = struct{}{}
+			prefixes = append(prefixes, commonPrefix)
+		}
+	}
+	return prefixes
+}
+
 func TestContentService_GetFiles_HidesGeneratedVariants(t *testing.T) {
 	manager := &listingOSManager{MockOSManager: &mocks.MockOSManager{}, objects: []minio.ObjectInfo{
 		{Key: "test@1.0.0/app.js"}, {Key: "test@1.0.0/app.js.br"}, {Key: "test@1.0.0/app.js.gz"},
 		{Key: "test@1.0.0/foo.tar"}, {Key: "test@1.0.0/foo.tar.gz"},
 	}}
 	service := NewContentService(manager, nil, 0, UploadLimits{})
-	files, err := service.GetFiles(context.Background(), "test", "1.0.0")
+	listing, err := service.GetFiles(context.Background(), "test", "1.0.0", "", 100)
 	require.Nil(t, err)
 	var names []string
-	for _, file := range files {
+	for _, file := range listing.Files {
 		names = append(names, file.Name)
 	}
 	assert.Equal(t, []string{"test@1.0.0/app.js", "test@1.0.0/foo.tar", "test@1.0.0/foo.tar.gz"}, names)
@@ -976,4 +1008,107 @@ func TestContentService_CreatePackage_RejectsEmptyArchive(t *testing.T) {
 
 	require.NotNil(t, err, "an archive with no file must be rejected")
 	assert.Equal(t, errors.ErrorKindEnum(errors.BadRequest), err.Kind)
+}
+
+func TestContentService_GetFiles_PartialVersionResolvesToOneVersion(t *testing.T) {
+	manager := &listingOSManager{MockOSManager: &mocks.MockOSManager{}, objects: []minio.ObjectInfo{
+		{Key: "mui@5.14.0/esm/Abc.js"},
+		{Key: "mui@5.15.21/esm/Abc.js"},
+		{Key: "mui@50.1.0/esm/Abc.js"},
+	}}
+	service := NewContentService(manager, nil, 0, UploadLimits{})
+	listing, err := service.GetFiles(context.Background(), "mui", "5", "", 100)
+	require.Nil(t, err)
+	var names []string
+	for _, file := range listing.Files {
+		names = append(names, file.Name)
+	}
+	assert.Equal(t, []string{"mui@5.15.21/esm/Abc.js"}, names)
+}
+
+func TestContentService_GetFiles_PinnedVersionDoesNotReachPrerelease(t *testing.T) {
+	manager := &listingOSManager{MockOSManager: &mocks.MockOSManager{}, objects: []minio.ObjectInfo{
+		{Key: "mui@1.0.0/app.js"},
+		{Key: "mui@1.0.0-beta/app.js"},
+	}}
+	service := NewContentService(manager, nil, 0, UploadLimits{})
+	listing, err := service.GetFiles(context.Background(), "mui", "1.0.0", "", 100)
+	require.Nil(t, err)
+	require.Len(t, listing.Files, 1)
+	assert.Equal(t, "mui@1.0.0/app.js", listing.Files[0].Name)
+}
+
+func TestContentService_GetFiles_PaginatesWithoutDuplicateOrGap(t *testing.T) {
+	manager := &listingOSManager{MockOSManager: &mocks.MockOSManager{}, objects: []minio.ObjectInfo{
+		{Key: "pkg@1.0.0/a.js"}, {Key: "pkg@1.0.0/b.js"}, {Key: "pkg@1.0.0/c.js"},
+	}}
+	service := NewContentService(manager, nil, 0, UploadLimits{})
+	first, err := service.GetFiles(context.Background(), "pkg", "1.0.0", "", 2)
+	require.Nil(t, err)
+	assert.True(t, first.HasMore)
+	second, err := service.GetFiles(context.Background(), "pkg", "1.0.0", first.Next, 2)
+	require.Nil(t, err)
+	assert.False(t, second.HasMore)
+	assert.Equal(t, []string{"pkg@1.0.0/a.js", "pkg@1.0.0/b.js", "pkg@1.0.0/c.js"}, []string{
+		first.Files[0].Name, first.Files[1].Name, second.Files[0].Name,
+	})
+}
+
+func TestContentService_GetFiles_HidesVariantAcrossPageBoundary(t *testing.T) {
+	manager := &listingOSManager{MockOSManager: &mocks.MockOSManager{}, objects: []minio.ObjectInfo{
+		{Key: "pkg@1.0.0/app.js"}, {Key: "pkg@1.0.0/app.js.br"}, {Key: "pkg@1.0.0/next.js"},
+	}}
+	service := NewContentService(manager, nil, 0, UploadLimits{})
+	first, err := service.GetFiles(context.Background(), "pkg", "1.0.0", "", 1)
+	require.Nil(t, err)
+	second, err := service.GetFiles(context.Background(), "pkg", "1.0.0", first.Next, 1)
+	require.Nil(t, err)
+	require.Len(t, second.Files, 1)
+	assert.Equal(t, "pkg@1.0.0/next.js", second.Files[0].Name)
+}
+
+func TestContentService_GetFiles_TotalKnownOnlyForFirstSinglePage(t *testing.T) {
+	manager := &listingOSManager{MockOSManager: &mocks.MockOSManager{}, objects: []minio.ObjectInfo{
+		{Key: "pkg@1.0.0/a.js"}, {Key: "pkg@1.0.0/b.js"},
+	}}
+	service := NewContentService(manager, nil, 0, UploadLimits{})
+	single, err := service.GetFiles(context.Background(), "pkg", "1.0.0", "", 10)
+	require.Nil(t, err)
+	assert.True(t, single.TotalKnown)
+	assert.Equal(t, 2, single.Total)
+
+	paged, err := service.GetFiles(context.Background(), "pkg", "1.0.0", "", 1)
+	require.Nil(t, err)
+	assert.False(t, paged.TotalKnown)
+}
+
+func TestContentService_GetFiles_HidesVariantOrphanedByPageBoundary(t *testing.T) {
+	manager := &listingOSManager{MockOSManager: &mocks.MockOSManager{}, objects: []minio.ObjectInfo{
+		{Key: "test@1.0.0/app.js"}, {Key: "test@1.0.0/app.js.br"}, {Key: "test@1.0.0/app.js.gz"},
+		{Key: "test@1.0.0/zeta.js"},
+	}}
+	service := NewContentService(manager, nil, 0, UploadLimits{})
+	listing, err := service.GetFiles(context.Background(), "test", "1.0.0", "test@1.0.0/app.js.br", 100)
+	require.Nil(t, err)
+	var names []string
+	for _, file := range listing.Files {
+		names = append(names, file.Name)
+	}
+	assert.Equal(t, []string{"test@1.0.0/zeta.js"}, names)
+}
+
+func TestContentService_GetFiles_AdvertisedNextPageIsNeverEmpty(t *testing.T) {
+	manager := &listingOSManager{MockOSManager: &mocks.MockOSManager{}, objects: []minio.ObjectInfo{
+		{Key: "test@1.0.0/a.js"}, {Key: "test@1.0.0/a.js.br"}, {Key: "test@1.0.0/a.js.gz"},
+	}}
+	service := NewContentService(manager, nil, 0, UploadLimits{})
+	first, err := service.GetFiles(context.Background(), "test", "1.0.0", "", 1)
+	require.Nil(t, err)
+	require.Equal(t, []string{"test@1.0.0/a.js"}, []string{first.Files[0].Name})
+	if !first.HasMore {
+		return
+	}
+	second, err := service.GetFiles(context.Background(), "test", "1.0.0", first.Next, 1)
+	require.Nil(t, err)
+	assert.NotEmpty(t, second.Files, "the Next cursor was advertised, so its page must not be empty (the controller 404s on an empty listing)")
 }

--- a/internal/storage/objectstorage-manager.go
+++ b/internal/storage/objectstorage-manager.go
@@ -54,8 +54,62 @@ type ObjectStorageManager interface {
 	GetObject(ctx context.Context, objectName string) (*minio.Object, *errors.GimmeError)
 	ObjectExists(ctx context.Context, objectName string) bool
 	ListObjects(ctx context.Context, objectParentName string) []minio.ObjectInfo
+	ListObjectsPage(ctx context.Context, prefix string, after string, limit int) ([]minio.ObjectInfo, bool)
+	ListCommonPrefixes(ctx context.Context, prefix string) []string
 	RemoveObjects(ctx context.Context, objectParentName string) *errors.GimmeError
 	Ping(ctx context.Context) *errors.GimmeError
+}
+
+// ListObjectsPage lists at most limit objects recursively and reports whether
+// another object exists after the returned page.
+func (osm *objectStorageManager) ListObjectsPage(ctx context.Context, prefix string, after string, limit int) ([]minio.ObjectInfo, bool) {
+	start := time.Now()
+	defer func() {
+		metrics.S3OperationDuration.WithLabelValues("ListObjectsPage").Observe(time.Since(start).Seconds())
+	}()
+
+	listCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	objectCh := osm.client.ListObjects(listCtx, osm.bucketName, minio.ListObjectsOptions{
+		Prefix:     prefix,
+		Recursive:  true,
+		MaxKeys:    limit + 1,
+		StartAfter: after,
+	})
+	objects := make([]minio.ObjectInfo, 0, limit)
+	for object := range objectCh {
+		if object.Err != nil {
+			logrus.Errorf("[ObjectStorageManager] ListObjectsPage - Error reading object from storage: %s", object.Err.Error())
+			continue
+		}
+		if len(objects) == limit {
+			return objects, true
+		}
+		objects = append(objects, object)
+	}
+	return objects, false
+}
+
+// ListCommonPrefixes lists the immediate child prefixes below prefix.
+func (osm *objectStorageManager) ListCommonPrefixes(ctx context.Context, prefix string) []string {
+	start := time.Now()
+	defer func() {
+		metrics.S3OperationDuration.WithLabelValues("ListCommonPrefixes").Observe(time.Since(start).Seconds())
+	}()
+
+	var prefixes []string
+	objectCh := osm.client.ListObjects(ctx, osm.bucketName, minio.ListObjectsOptions{
+		Prefix:    prefix,
+		Recursive: false,
+	})
+	for object := range objectCh {
+		if object.Err != nil {
+			logrus.Errorf("[ObjectStorageManager] ListCommonPrefixes - Error reading object from storage: %s", object.Err.Error())
+			continue
+		}
+		prefixes = append(prefixes, object.Key)
+	}
+	return prefixes
 }
 
 // AddBytes adds an in-memory object into the bucket.

--- a/internal/storage/objectstorage-manager_test.go
+++ b/internal/storage/objectstorage-manager_test.go
@@ -109,6 +109,34 @@ func TestObjectStorageManager_ListObjects(t *testing.T) {
 	assert.Equal(t, "test", objs[0].ETag)
 }
 
+func TestObjectStorageManager_ListObjectsPage(t *testing.T) {
+	client := &mocks.MockOSClient{Objects: []minio.ObjectInfo{{Key: "pkg/a"}, {Key: "pkg/b"}, {Key: "pkg/c"}}}
+	osm := NewObjectStorageManager(client)
+
+	objects, hasMore := osm.ListObjectsPage(context.Background(), "pkg/", "", 2)
+	require.Len(t, objects, 2)
+	assert.Equal(t, []string{"pkg/a", "pkg/b"}, []string{objects[0].Key, objects[1].Key})
+	assert.True(t, hasMore)
+}
+
+func TestObjectStorageManager_ListObjectsPageShortListing(t *testing.T) {
+	client := &mocks.MockOSClient{Objects: []minio.ObjectInfo{{Key: "pkg/a"}, {Key: "pkg/b"}}}
+	osm := NewObjectStorageManager(client)
+
+	objects, hasMore := osm.ListObjectsPage(context.Background(), "pkg/", "", 3)
+	assert.Len(t, objects, 2)
+	assert.False(t, hasMore)
+}
+
+func TestObjectStorageManager_ListCommonPrefixes(t *testing.T) {
+	client := &mocks.MockOSClient{Objects: []minio.ObjectInfo{
+		{Key: "mui@5.14.0/a.js"}, {Key: "mui@5.14.0/b.js"}, {Key: "mui@5.15.21/a.js"},
+	}}
+	osm := NewObjectStorageManager(client)
+
+	assert.Equal(t, []string{"mui@5.14.0/", "mui@5.15.21/"}, osm.ListCommonPrefixes(context.Background(), "mui@"))
+}
+
 func TestObjectStorageManager_RemoveObjects(t *testing.T) {
 	osm := NewObjectStorageManager(&mocks.MockOSClient{})
 	err := osm.RemoveObjects(context.Background(), "test")

--- a/templates/package.tmpl
+++ b/templates/package.tmpl
@@ -474,7 +474,8 @@
           </svg>
           {{ .packageName }}
         </span>
-        <span class="file-count" id="file-count" aria-live="polite"></span>
+        <span class="file-count" id="file-count" aria-live="polite">{{ if .totalKnown }}{{ .total }} file{{ if ne .total 1 }}s{{ end }}{{ else }}{{ .fileCount }} file{{ if ne .fileCount 1 }}s{{ end }} shown{{ end }}</span>
+		<span class="file-count">Resolved version: {{ .resolvedVersion }}</span>
       </div>
     </div>
 
@@ -535,6 +536,12 @@
       <p>No files found in this package.</p>
     </div>
     {{ end }}
+
+	{{ if .hasMore }}
+	<nav aria-label="Package pagination" style="margin-top: 1rem; text-align: right;">
+	  <a href="{{ .nextURL }}">Next</a>
+	</nav>
+	{{ end }}
 
   </main>
 
@@ -629,13 +636,6 @@
           }
         }
       });
-
-      /* ---- File count ---- */
-      var rows = document.querySelectorAll('#file-tbody tr');
-      var countEl = document.getElementById('file-count');
-      if (countEl && rows.length > 0) {
-        countEl.textContent = rows.length + ' file' + (rows.length !== 1 ? 's' : '');
-      }
 
       /* ---- Toast ---- */
       var toast = document.getElementById('toast');

--- a/test/mocks/objectstorage-client.go
+++ b/test/mocks/objectstorage-client.go
@@ -3,12 +3,15 @@ package mocks
 import (
 	"context"
 	"io"
+	"sort"
+	"strings"
 
 	"github.com/minio/minio-go/v7"
 )
 
 type MockOSClient struct {
 	PutObjectOptions []minio.PutObjectOptions
+	Objects          []minio.ObjectInfo
 }
 
 func (osc *MockOSClient) MakeBucket(_ context.Context, _ string, _ minio.MakeBucketOptions) error {
@@ -27,10 +30,40 @@ func (osc *MockOSClient) GetObject(_ context.Context, _ string, _ string, _ mini
 	return &minio.Object{}, nil
 }
 
-func (osc *MockOSClient) ListObjects(_ context.Context, _ string, _ minio.ListObjectsOptions) <-chan minio.ObjectInfo {
-	ch := make(chan minio.ObjectInfo, 1)
-	defer close(ch)
-	ch <- minio.ObjectInfo{ETag: "test"}
+func (osc *MockOSClient) ListObjects(ctx context.Context, _ string, opts minio.ListObjectsOptions) <-chan minio.ObjectInfo {
+	ch := make(chan minio.ObjectInfo)
+	go func() {
+		defer close(ch)
+		objects := make([]minio.ObjectInfo, len(osc.Objects))
+		copy(objects, osc.Objects)
+		if len(objects) == 0 {
+			objects = []minio.ObjectInfo{{Key: "test/file.js", ETag: "test"}}
+		}
+		sort.Slice(objects, func(i, j int) bool { return objects[i].Key < objects[j].Key })
+		seen := map[string]struct{}{}
+		for _, object := range objects {
+			if !strings.HasPrefix(object.Key, opts.Prefix) || object.Key <= opts.StartAfter {
+				continue
+			}
+			if !opts.Recursive {
+				rest := strings.TrimPrefix(object.Key, opts.Prefix)
+				child, _, found := strings.Cut(rest, "/")
+				if !found {
+					continue
+				}
+				object = minio.ObjectInfo{Key: opts.Prefix + child + "/"}
+				if _, exists := seen[object.Key]; exists {
+					continue
+				}
+				seen[object.Key] = struct{}{}
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- object:
+			}
+		}
+	}()
 	return ch
 }
 

--- a/test/mocks/objectstorage-manager-err.go
+++ b/test/mocks/objectstorage-manager-err.go
@@ -33,6 +33,14 @@ func (osc *MockOSManagerErr) ListObjects(_ context.Context, _ string) []minio.Ob
 	return []minio.ObjectInfo{}
 }
 
+func (osc *MockOSManagerErr) ListObjectsPage(_ context.Context, _ string, _ string, _ int) ([]minio.ObjectInfo, bool) {
+	return nil, false
+}
+
+func (osc *MockOSManagerErr) ListCommonPrefixes(_ context.Context, _ string) []string {
+	return nil
+}
+
 func (osc *MockOSManagerErr) RemoveObjects(_ context.Context, _ string) *errors.GimmeError {
 	return errors.NewBusinessError(errors.InternalError, fmt.Errorf("boom"))
 }

--- a/test/mocks/objectstorage-manager-exists.go
+++ b/test/mocks/objectstorage-manager-exists.go
@@ -33,6 +33,14 @@ func (osc *MockOSManagerExists) ListObjects(_ context.Context, _ string) []minio
 	return []minio.ObjectInfo{}
 }
 
+func (osc *MockOSManagerExists) ListObjectsPage(_ context.Context, _ string, _ string, _ int) ([]minio.ObjectInfo, bool) {
+	return nil, false
+}
+
+func (osc *MockOSManagerExists) ListCommonPrefixes(_ context.Context, _ string) []string {
+	return nil
+}
+
 func (osc *MockOSManagerExists) RemoveObjects(_ context.Context, _ string) *errors.GimmeError {
 	return nil
 }

--- a/test/mocks/objectstorage-manager-fail-after.go
+++ b/test/mocks/objectstorage-manager-fail-after.go
@@ -21,6 +21,8 @@ type OSManager interface {
 	GetObject(ctx context.Context, objectName string) (*minio.Object, *errors.GimmeError)
 	ObjectExists(ctx context.Context, objectName string) bool
 	ListObjects(ctx context.Context, objectParentName string) []minio.ObjectInfo
+	ListObjectsPage(ctx context.Context, prefix string, after string, limit int) ([]minio.ObjectInfo, bool)
+	ListCommonPrefixes(ctx context.Context, prefix string) []string
 	RemoveObjects(ctx context.Context, objectParentName string) *errors.GimmeError
 	Ping(ctx context.Context) *errors.GimmeError
 }

--- a/test/mocks/objectstorage-manager.go
+++ b/test/mocks/objectstorage-manager.go
@@ -114,6 +114,40 @@ func (osc *MockOSManager) ListObjects(_ context.Context, fileName string) []mini
 	return objs
 }
 
+func (osc *MockOSManager) ListObjectsPage(ctx context.Context, prefix string, after string, limit int) ([]minio.ObjectInfo, bool) {
+	objects := osc.ListObjects(ctx, prefix)
+	page := make([]minio.ObjectInfo, 0, limit)
+	for _, object := range objects {
+		if object.Key <= after {
+			continue
+		}
+		if len(page) == limit {
+			return page, true
+		}
+		page = append(page, object)
+	}
+	return page, false
+}
+
+func (osc *MockOSManager) ListCommonPrefixes(ctx context.Context, prefix string) []string {
+	seen := map[string]struct{}{}
+	var prefixes []string
+	for _, object := range osc.ListObjects(ctx, prefix) {
+		rest := strings.TrimPrefix(object.Key, prefix)
+		version, _, found := strings.Cut(rest, "/")
+		if !found || version == "" {
+			continue
+		}
+		commonPrefix := prefix + version + "/"
+		if _, exists := seen[commonPrefix]; exists {
+			continue
+		}
+		seen[commonPrefix] = struct{}{}
+		prefixes = append(prefixes, commonPrefix)
+	}
+	return prefixes
+}
+
 func (osc *MockOSManager) RemoveObjects(_ context.Context, _ string) *errors.GimmeError {
 	return nil
 }


### PR DESCRIPTION
Closes #84.

`GET /gimme/<pkg>@<version>` returned every object under the prefix in one response. Reproduced with the real `@mui/icons-material@5.15.21` (31 843 files) against Garage v1.3.1: **54 MB of HTML, 1.47 s**. The issue measured 39.7 MB — the page has grown since, #120 added an SRI button to every row.

A second defect shipped in the same function: `GetFiles` built its prefix as `pkg@version`, with no trailing slash and no version resolution. S3 prefix matching is textual, so `mui-icons@5` matched `5.14.0`, `5.15.21` **and `50.1.0`**, and interleaved them into one page with nothing saying which version each row belonged to.

## The contract

Keyset pagination — `?limit=N` (default 50, clamped to `[1, 500]`) and `?after=<last raw object key>`, which maps onto S3 `StartAfter`. Verified in minio-go v7.3.0: `ListObjects` and `ListObjectsIter` are the only public listing methods and neither exposes a continuation token, so `StartAfter` is the whole of the available cursor.

Offset pagination and numbered page links were rejected: S3 has no offset, so `?page=100` would re-drain 10 000 keys and reintroduce the defect on the later pages.

JSON rides the existing route under `Accept: application/json`, negotiated so a browser's `Accept` and a bare `*/*` both still get HTML. It carries a `Link` header with `rel="first"` and `rel="next"`. There is no `rel="prev"` and no `rel="last"` — neither is derivable from a keyset cursor, which is also why the HTML has a Next link and no Previous. GitLab's keyset mode makes the same two omissions.

`total` is reported only when the whole listing fits in one page, the single case where it is free. There is no per-prefix count in S3, `ListBucketV2Result` has no `KeyCount` field in this version, and the admin APIs that do count objects are bucket-level and need admin credentials.

Version resolution goes through a non-recursive list on `pkg@`, which returns one common prefix per version. The listing prefix is now `pkg@<resolved>/` **with the slash** — its absence is also what let `mui@1.0.0` reach `mui@1.0.0-beta`. The partial-match predicate settled in #45 and #46 was extracted into `versionMatches` and is shared with `filterArray`, so the two resolution paths cannot drift.

## Proven red first

```
=== RUN   TestContentService_GetFiles_PartialVersionResolvesToOneVersion
    Error: Not equal:
      expected: []string{"mui@5.15.21/esm/Abc.js"}
      actual  : []string{"mui@5.14.0/esm/Abc.js", "mui@5.15.21/esm/Abc.js",
                         "mui@50.1.0/esm/Abc.js"}
--- FAIL: TestContentService_GetFiles_PartialVersionResolvesToOneVersion (0.00s)
```

Two further defects surfaced in review, each also proven by its own failing test before being fixed:

```
=== RUN   TestContentService_GetFiles_HidesVariantOrphanedByPageBoundary
    Error: Not equal:
      expected: []string{"test@1.0.0/zeta.js"}
      actual  : []string{"test@1.0.0/app.js.gz", "test@1.0.0/zeta.js"}
--- FAIL

=== RUN   TestContentService_GetFiles_AdvertisedNextPageIsNeverEmpty
    Error: Should NOT be empty, but was []
    Messages: the Next cursor was advertised, so its page must not be empty
              (the controller 404s on an empty listing)
--- FAIL
```

The first: a `.br`/`.gz` variant is hidden by looking its identity sibling up in the set of listed keys, so a page opening on `app.js.gz` whose sibling `app.js` fell on the previous page showed the variant as a file. The cursor's own identity sibling is now seeded into that set.

The second: `HasMore` computed from raw keys advertised a Next link to a page holding nothing but filtered-out variants — a 404 on a link just rendered. A page is now advertised only once a *visible* file is known to be on it, by collecting `limit + 1` and resuming from the raw key preceding the extra one. That look-ahead is why a listing costs two `ListObjectsPage` calls rather than one.

## Measured

Two instances over the same Garage bucket, one on `00d478f`, one on this branch, with the real package loaded.

| | before | after |
|---|---|---|
| listing, one request | 54 375 555 B / 1.47 s | **105 130 B / 0.053 s** |
| listing, load (c=20, n=400) | 1.3 req/s (at c=2) | **213 req/s**, p50 92 ms |
| versions listed by `@5` | `5.14.0`, `5.15.21`, `50.1.0` | `5.15.21` only |

Walking every page of the 31 843-file package end to end: 800 unique files over 8 pages, no duplicate, no gap, no encoded variant leaked, no dangling `rel="next"` on the last page.

End-to-end check that serving still works with integrity: `canvas-confetti@1.9.3` uploaded to a local instance and loaded cross-origin from a page on another port. The `Gimme-Integrity` header, an independent `openssl sha384` over the served bytes, and the original npm file all agree, with `Access-Control-Allow-Origin: *` present so the browser can verify it.

## One caveat worth recording

`ListCommonPrefixes` is constant in package size, but it is not free. From the service's own `gimme_s3_operation_duration_seconds` histogram: 12.9 ms alone, **234 ms at concurrency 20**, against 44.5 ms for `ListObjectsPage`. The same call on a 6-object package measures 239 ms — indistinguishable, which is what confirms the cost does not track package size. That one extra round trip per request is why a partial-version listing serves 48 req/s where a pinned one serves 213.

## Deliberately out of scope

`getLatestPackagePath` is untouched. It pays the same full drain on the asset-serving hot path — measured at **1.4 req/s and a 3.46 s p50** for a partial-version file request against **1540 req/s** pinned, same file, same package, only the version form differing. That is #85, which reuses the primitive added here; folding it in would have made one diff out of two reviewable ones.

Also adds a `TODO.md` entry for #122, opened while validating this: the listing is bounded now but still flat, and browsing by folder needs both that shape and this pagination.

## Checks

`gofmt -l .` silent · `golangci-lint run ./...` → `0 issues.` · `make test` all packages ok, `api` at 92.9% · `make build` ok.
